### PR TITLE
Add extensions for MSTest V2 framework.

### DIFF
--- a/ArchUnit.sln
+++ b/ArchUnit.sln
@@ -5,17 +5,21 @@ VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestAssembly", "TestAssembly\TestAssembly.csproj", "{7DEF5F34-AB86-457B-819D-5E7387B3FF87}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchUnitNET", "ArchUnitNET\ArchUnitNET.csproj", "{2855911F-6AE2-4BE1-BA88-9A0B2A03BFA3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArchUnitNET", "ArchUnitNET\ArchUnitNET.csproj", "{2855911F-6AE2-4BE1-BA88-9A0B2A03BFA3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchUnitNETTests", "ArchUnitNETTests\ArchUnitNETTests.csproj", "{F38CBB2C-BDD0-4195-82CB-8B76332B0890}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArchUnitNETTests", "ArchUnitNETTests\ArchUnitNETTests.csproj", "{F38CBB2C-BDD0-4195-82CB-8B76332B0890}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleTest", "ExampleTest\ExampleTest.csproj", "{180688C2-7917-4A23-89A7-F3D5317E54F3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleTest", "ExampleTest\ExampleTest.csproj", "{180688C2-7917-4A23-89A7-F3D5317E54F3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchUnitNET.xUnit", "ArchUnitNET.xUnit\ArchUnitNET.xUnit.csproj", "{53DF58F8-0C82-4259-96A6-31974D0A503A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArchUnitNET.xUnit", "ArchUnitNET.xUnit\ArchUnitNET.xUnit.csproj", "{53DF58F8-0C82-4259-96A6-31974D0A503A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchUnitNET.NUnit", "ArchUnitNET.NUnit\ArchUnitNET.NUnit.csproj", "{0BD564F3-D34F-4D39-94B3-EA2705EDF594}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArchUnitNET.NUnit", "ArchUnitNET.NUnit\ArchUnitNET.NUnit.csproj", "{0BD564F3-D34F-4D39-94B3-EA2705EDF594}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchUnitNET.NUnitTests", "ArchUnitNET.NUnitTests\ArchUnitNET.NUnitTests.csproj", "{D2AB683F-0A64-491E-9C56-EE98588C493C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArchUnitNET.NUnitTests", "ArchUnitNET.NUnitTests\ArchUnitNET.NUnitTests.csproj", "{D2AB683F-0A64-491E-9C56-EE98588C493C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchUnitNET.MSTestV2", "ArchUnitNET.MSTestV2\ArchUnitNET.MSTestV2.csproj", "{3D057987-358A-41C6-AF55-6490FCA5875F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchUnitNET.MSTestV2Tests", "ArchUnitNET.MSTestV2Tests\ArchUnitNET.MSTestV2Tests.csproj", "{6D6B6EFE-DA0B-4C4D-B710-FA658F0C68CF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +55,14 @@ Global
 		{D2AB683F-0A64-491E-9C56-EE98588C493C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D2AB683F-0A64-491E-9C56-EE98588C493C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D2AB683F-0A64-491E-9C56-EE98588C493C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D057987-358A-41C6-AF55-6490FCA5875F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D057987-358A-41C6-AF55-6490FCA5875F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D057987-358A-41C6-AF55-6490FCA5875F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D057987-358A-41C6-AF55-6490FCA5875F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D6B6EFE-DA0B-4C4D-B710-FA658F0C68CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D6B6EFE-DA0B-4C4D-B710-FA658F0C68CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D6B6EFE-DA0B-4C4D-B710-FA658F0C68CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D6B6EFE-DA0B-4C4D-B710-FA658F0C68CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ArchUnitNET.MSTestV2/ArchRuleAssert.cs
+++ b/ArchUnitNET.MSTestV2/ArchRuleAssert.cs
@@ -1,0 +1,29 @@
+﻿//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Paula Ruiz <paularuiz22@gmail.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 
+// 	SPDX-License-Identifier: Apache-2.0
+
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Fluent.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ArchUnitNET.MSTestV2
+{
+    public static class ArchRuleAssert
+    {
+        /// <summary>
+        ///     Verifies that the architecture meets the criteria of the archrule.
+        /// </summary>
+        /// <param name="architecture">The architecture to be tested</param>
+        /// <param name="archRule">The rule to test the architecture with</param>
+        public static void FulfilsRule(Architecture architecture, IArchRule archRule)
+        {
+            if (!archRule.HasNoViolations(architecture))
+            {
+                Assert.Fail(archRule.Evaluate(architecture).ToErrorMessage());
+            }
+        }
+    }
+}

--- a/ArchUnitNET.MSTestV2/ArchRuleExtensions.cs
+++ b/ArchUnitNET.MSTestV2/ArchRuleExtensions.cs
@@ -1,0 +1,34 @@
+﻿//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Paula Ruiz <paularuiz22@gmail.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 
+// 	SPDX-License-Identifier: Apache-2.0
+
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+
+namespace ArchUnitNET.MSTestV2
+{
+    public static class ArchRuleExtensions
+    {
+        /// <summary>
+        ///     Verifies that the architecture meets the criteria of the archrule.
+        /// </summary>
+        /// <param name="archRule">The rule to test the architecture with</param>
+        /// <param name="architecture">The architecture to be tested</param>
+        public static void Check(this IArchRule archRule, Architecture architecture)
+        {
+            ArchRuleAssert.FulfilsRule(architecture, archRule);
+        }
+
+        /// <summary>
+        ///     Verifies that the architecture meets the criteria of the archrule.
+        /// </summary>
+        /// <param name="architecture">The architecture to be tested</param>
+        /// <param name="archRule">The rule to test the architecture with</param>
+        public static void CheckRule(this Architecture architecture, IArchRule archRule)
+        {
+            ArchRuleAssert.FulfilsRule(architecture, archRule);
+        }
+    }
+}

--- a/ArchUnitNET.MSTestV2/ArchUnitNET.MSTestV2.csproj
+++ b/ArchUnitNET.MSTestV2/ArchUnitNET.MSTestV2.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ArchUnitNET.MSTestV2/ArchUnitNET.MSTestV2.csproj
+++ b/ArchUnitNET.MSTestV2/ArchUnitNET.MSTestV2.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <Title>ArchUnit C# MSTestV2 Extension</Title>
     <Authors>Florian Gather, Fritz Brandhuber</Authors>
-    <Description>NUnit Extension for the C# Version of ArchUnit (see: archunit.org)</Description>
+    <Description>MSTestV2 Extension for the C# Version of ArchUnit (see: archunit.org)</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/TNG/ArchUnitNET</RepositoryUrl>
     <PackageTags>test;arch;archunit;mstest;mstestv2</PackageTags>

--- a/ArchUnitNET.MSTestV2/ArchUnitNET.MSTestV2.csproj
+++ b/ArchUnitNET.MSTestV2/ArchUnitNET.MSTestV2.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <Title>ArchUnit C# MSTestV2 Extension</Title>
+    <Authors>Florian Gather, Fritz Brandhuber</Authors>
+    <Description>NUnit Extension for the C# Version of ArchUnit (see: archunit.org)</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/TNG/ArchUnitNET</RepositoryUrl>
+    <PackageTags>test;arch;archunit;mstest;mstestv2</PackageTags>
+    <PackageReleaseNotes>Initial release</PackageReleaseNotes>
+    <IncludeSource>False</IncludeSource>
+    <Company>TNG Technology Consulting GmbH</Company>
+    <PackageId>TngTech.ArchUnitNET.MSTestV2</PackageId>
+    <IsTestProject>false</IsTestProject>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ArchUnitNET\ArchUnitNET.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ArchUnitNET.MSTestV2Tests/ArchUnitNET.MSTestV2Tests.csproj
+++ b/ArchUnitNET.MSTestV2Tests/ArchUnitNET.MSTestV2Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <Company>TNG Technology Consulting GmbH</Company>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ArchUnitNET.MSTestV2\ArchUnitNET.MSTestV2.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ArchUnitNET.MSTestV2Tests/ArchUnitNET.MSTestV2Tests.csproj
+++ b/ArchUnitNET.MSTestV2Tests/ArchUnitNET.MSTestV2Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/ArchUnitNET.MSTestV2Tests/ArchUnitNET.MSTestV2Tests.csproj
+++ b/ArchUnitNET.MSTestV2Tests/ArchUnitNET.MSTestV2Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ArchUnitNET.MSTestV2Tests/RuleEvaluationTests.cs
+++ b/ArchUnitNET.MSTestV2Tests/RuleEvaluationTests.cs
@@ -1,0 +1,60 @@
+//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Paula Ruiz <paularuiz22@gmail.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 
+// 	SPDX-License-Identifier: Apache-2.0
+
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Fluent.Extensions;
+using ArchUnitNET.Loader;
+using ArchUnitNET.MSTestV2;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+namespace ArchUnitNET.MSTestV2Tests
+{
+    [TestClass]
+    public class RuleEvaluationTests
+    {
+        private static Architecture _architecture;
+        private static string _expectedErrorMessage;
+        private static IArchRule _falseRule;
+        private static IArchRule _trueRule;
+
+        [ClassInitialize]
+        public static void Setup(TestContext context)
+        {
+            _architecture = new ArchLoader().LoadAssemblies(typeof(RuleEvaluationTests).Assembly).Build();
+            _trueRule = Classes().That().Are(typeof(RuleEvaluationTests)).Should().Exist();
+            _falseRule = Classes().That().Are(typeof(RuleEvaluationTests)).Should().NotExist();
+            _expectedErrorMessage = _falseRule.Evaluate(_architecture).ToErrorMessage();
+        }
+
+        [TestMethod]
+        public void ArchRuleAssertTest()
+        {
+            ArchRuleAssert.FulfilsRule(_architecture, _trueRule);
+            Assert.ThrowsException<AssertFailedException>(() => ArchRuleAssert.FulfilsRule(_architecture, _falseRule));
+            Assert.AreEqual(_expectedErrorMessage,
+                RemoveAssertionText(Assert.ThrowsException<AssertFailedException>(() => ArchRuleAssert.FulfilsRule(_architecture, _falseRule)).Message));
+        }
+
+        [TestMethod]
+        public void ArchRuleExtensionsTest()
+        {
+            _architecture.CheckRule(_trueRule);
+            _trueRule.Check(_architecture);
+            Assert.ThrowsException<AssertFailedException>(() => _architecture.CheckRule(_falseRule));
+            Assert.ThrowsException<AssertFailedException>(() => _falseRule.Check(_architecture));
+            Assert.AreEqual(_expectedErrorMessage,
+                RemoveAssertionText(Assert.ThrowsException<AssertFailedException>(() => _architecture.CheckRule(_falseRule)).Message));
+            Assert.AreEqual(_expectedErrorMessage,
+                RemoveAssertionText(Assert.ThrowsException<AssertFailedException>(() => _falseRule.Check(_architecture)).Message));
+        }
+
+        private static string RemoveAssertionText(string exceptionMessage) {
+          return exceptionMessage.Replace("Assert.Fail failed. ", string.Empty);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If you want to use xUnit or NUnit for your unit tests, you should instead instal
 ```
 PS> Install-Package ArchUnitNET.xUnit
 PS> Install-Package ArchUnitNET.NUnit
+PS> Install-Package ArchUnitNET.MSTestV2
 ```
 #### Create a Test
 Then you will want to create a class to start testing. We used xUnit with the ArchUnit extension here, but it works similarly with NUnit or other Unit Test Frameworks.

--- a/Travis/deploy.ps1
+++ b/Travis/deploy.ps1
@@ -6,3 +6,4 @@ param(
 dotnet nuget push ($PWD.Path + "\ArchUnitNET\nupkgs\TngTech.ArchUnitNET.*.nupkg") -k $apiKey -s $source
 dotnet nuget push ($PWD.Path + "\ArchUnitNET.xUnit\nupkgs\TngTech.ArchUnitNET.xUnit.*.nupkg") -k $apiKey -s $source
 dotnet nuget push ($PWD.Path + "\ArchUnitNET.NUnit\nupkgs\TngTech.ArchUnitNET.NUnit.*.nupkg") -k $apiKey -s $source
+dotnet nuget push ($PWD.Path + "\ArchUnitNET.MSTestV2\nupkgs\TngTech.ArchUnitNET.MSTestV2.*.nupkg") -k $apiKey -s $source


### PR DESCRIPTION
A new package referencing MSTestV2 is created for adding the same shortcuts as in ArchUnitNET.NUnit.
This would reduce the usage of ArchUnitNET with MSTestV2 including meaningful messages from:
```csharp
[TestMethod]
public void ExampleCycleCheck()
{
    IArchRule rule = Slices().Matching("..").Should().BeFreeOfCycles();

    if (!archRule.HasNoViolations(_architecture))
    {
        Assert.Fail(archRule.Evaluate(architecture).ToErrorMessage());
    }
}
```

To:
```csharp
[TestMethod]
public void ExampleCycleCheck()
{
    IArchRule rule = Slices().Matching("..").Should().BeFreeOfCycles();

    rule.Check(_architecture);
}
```

Please create and upload the according Nuget packages.