### PR TITLE
Handle fixed size buffers

### DIFF
--- a/ArchUnitNETTests/ArchUnitNETTests.csproj
+++ b/ArchUnitNETTests/ArchUnitNETTests.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <LangVersion>7.2</LangVersion>
         <Company>TNG Technology Consulting GmbH</Company>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ArchUnitNETTests/Domain/FixedSizeBufferTests.cs
+++ b/ArchUnitNETTests/Domain/FixedSizeBufferTests.cs
@@ -5,6 +5,7 @@
 // 	SPDX-License-Identifier: Apache-2.0
 // 
 
+using System.Collections.Generic;
 using System.Linq;
 using ArchUnitNET.Domain;
 using ArchUnitNET.Domain.Extensions;
@@ -18,7 +19,7 @@ namespace ArchUnitNETTests.Domain
         private static readonly Architecture Architecture =
             new ArchLoader().LoadAssembly(typeof(FixedSizeBufferTests).Assembly).Build();
 
-        private Class _structWithUnsafeContent;
+        private readonly Class _structWithUnsafeContent;
 
         public FixedSizeBufferTests()
         {
@@ -26,11 +27,15 @@ namespace ArchUnitNETTests.Domain
         }
 
         [Fact]
-        public void NoCompilerGeneratedFieldTest()
+        public void HandleFixedSizeBuffersCorrectly()
         {
             var fieldMembers = _structWithUnsafeContent.GetFieldMembers().ToList();
             Assert.Single(fieldMembers);
             Assert.False(fieldMembers[0].Type.IsCompilerGenerated);
+            var fieldTypeDependency = _structWithUnsafeContent.GetFieldTypeDependencies().First();
+            Assert.Equal(typeof(char).FullName,fieldTypeDependency.Target.FullName);
+            Assert.Equal(new List<int>{1},fieldTypeDependency.TargetArrayDimensions);
+            Assert.True(fieldTypeDependency.TargetIsArray);
         }
     }
 

--- a/ArchUnitNETTests/Domain/FixedSizeBufferTests.cs
+++ b/ArchUnitNETTests/Domain/FixedSizeBufferTests.cs
@@ -1,0 +1,41 @@
+//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+// 
+// 	SPDX-License-Identifier: Apache-2.0
+// 
+
+using System.Linq;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Domain.Extensions;
+using ArchUnitNET.Loader;
+using Xunit;
+
+namespace ArchUnitNETTests.Domain
+{
+    public class FixedSizeBufferTests
+    {
+        private static readonly Architecture Architecture =
+            new ArchLoader().LoadAssembly(typeof(FixedSizeBufferTests).Assembly).Build();
+
+        private Class _structWithUnsafeContent;
+
+        public FixedSizeBufferTests()
+        {
+            _structWithUnsafeContent = Architecture.GetClassOfType(typeof(StructWithFixedSizeBuffer));
+        }
+
+        [Fact]
+        public void NoCompilerGeneratedFieldTest()
+        {
+            var fieldMembers = _structWithUnsafeContent.GetFieldMembers().ToList();
+            Assert.Single(fieldMembers);
+            Assert.False(fieldMembers[0].Type.IsCompilerGenerated);
+        }
+    }
+
+    public struct StructWithFixedSizeBuffer
+    {
+        public unsafe fixed char FixedCharArray[256];
+    }
+}


### PR DESCRIPTION
This fixes an issue, where fixed size buffers (eg. `unsafe fixed char buffer[256]`) were not assigned the correct field type (eg. `char[]`) but instead had a compiler generated field type.