### PR TITLE
Allow regex matching on name and full name when providing a string pattern

### DIFF
--- a/ArchUnitNET/Fluent/Syntax/Elements/GivenObjectsThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/GivenObjectsThat.cs
@@ -388,9 +388,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TGivenRuleTypeConjunction HaveNameMatching(string pattern)
+        public TGivenRuleTypeConjunction HaveNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.HaveNameMatching(pattern));
+            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.HaveNameMatching(pattern, useRegularExpressions));
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -400,9 +400,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TGivenRuleTypeConjunction HaveFullNameMatching(string pattern)
+        public TGivenRuleTypeConjunction HaveFullNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.HaveFullNameMatching(pattern));
+            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.HaveFullNameMatching(pattern, useRegularExpressions));
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -738,9 +738,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TGivenRuleTypeConjunction DoNotHaveNameMatching(string pattern)
+        public TGivenRuleTypeConjunction DoNotHaveNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.DoNotHaveNameMatching(pattern));
+            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.DoNotHaveNameMatching(pattern, useRegularExpressions));
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -750,9 +750,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TGivenRuleTypeConjunction DoNotHaveFullNameMatching(string pattern)
+        public TGivenRuleTypeConjunction DoNotHaveFullNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.DoNotHaveFullNameMatching(pattern));
+            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.DoNotHaveFullNameMatching(pattern, useRegularExpressions));
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 

--- a/ArchUnitNET/Fluent/Syntax/Elements/IObjectConditions.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/IObjectConditions.cs
@@ -73,9 +73,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         TReturnType HaveAttributeWithNamedArguments(Type attribute, IEnumerable<(string,object)> attributeArguments);
         TReturnType HaveAttributeWithNamedArguments(Type attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
         TReturnType HaveName(string name);
-        TReturnType HaveNameMatching(string pattern);
+        TReturnType HaveNameMatching(string pattern, bool useRegularExpressions = false);
         TReturnType HaveFullName(string fullname);
-        TReturnType HaveFullNameMatching(string pattern);
+        TReturnType HaveFullNameMatching(string pattern, bool useRegularExpressions = false);
         TReturnType HaveNameStartingWith(string pattern);
         TReturnType HaveNameEndingWith(string pattern);
         TReturnType HaveNameContaining(string pattern);
@@ -129,9 +129,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         TReturnType NotHaveAttributeWithNamedArguments(Type attribute, IEnumerable<(string,object)> attributeArguments);
         TReturnType NotHaveAttributeWithNamedArguments(Type attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
         TReturnType NotHaveName(string name);
-        TReturnType NotHaveNameMatching(string pattern);
+        TReturnType NotHaveNameMatching(string pattern, bool useRegularExpressions = false);
         TReturnType NotHaveFullName(string fullname);
-        TReturnType NotHaveFullNameMatching(string pattern);
+        TReturnType NotHaveFullNameMatching(string pattern, bool useRegularExpressions = false);
         TReturnType NotHaveNameStartingWith(string pattern);
         TReturnType NotHaveNameEndingWith(string pattern);
         TReturnType NotHaveNameContaining(string pattern);

--- a/ArchUnitNET/Fluent/Syntax/Elements/IObjectPredicates.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/IObjectPredicates.cs
@@ -71,9 +71,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         TReturnType HaveAttributeWithNamedArguments(Type attribute, IEnumerable<(string,object)> attributeArguments);
         TReturnType HaveAttributeWithNamedArguments(Type attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
         TReturnType HaveName(string name);
-        TReturnType HaveNameMatching(string pattern);
+        TReturnType HaveNameMatching(string pattern, bool useRegularExpressions = false);
         TReturnType HaveFullName(string fullname);
-        TReturnType HaveFullNameMatching(string pattern);
+        TReturnType HaveFullNameMatching(string pattern, bool useRegularExpressions = false);
         TReturnType HaveNameStartingWith(string pattern);
         TReturnType HaveNameEndingWith(string pattern);
         TReturnType HaveNameContaining(string pattern);
@@ -130,9 +130,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         TReturnType DoNotHaveAttributeWithNamedArguments(Type attribute, IEnumerable<(string,object)> attributeArguments);
         TReturnType DoNotHaveAttributeWithNamedArguments(Type attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
         TReturnType DoNotHaveName(string name);
-        TReturnType DoNotHaveNameMatching(string pattern);
+        TReturnType DoNotHaveNameMatching(string pattern, bool useRegularExpressions = false);
         TReturnType DoNotHaveFullName(string fullname);
-        TReturnType DoNotHaveFullNameMatching(string pattern);
+        TReturnType DoNotHaveFullNameMatching(string pattern, bool useRegularExpressions = false);
         TReturnType DoNotHaveNameStartingWith(string pattern);
         TReturnType DoNotHaveNameEndingWith(string pattern);
         TReturnType DoNotHaveNameContaining(string pattern);

--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
@@ -1569,11 +1569,11 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                 obj => obj.Name.Equals(name), obj => "does have name " + obj.Name, "have name \"" + name + "\"");
         }
 
-        public static SimpleCondition<TRuleType> HaveNameMatching(string pattern)
+        public static SimpleCondition<TRuleType> HaveNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            return new SimpleCondition<TRuleType>(obj => obj.NameMatches(pattern),
+            return new SimpleCondition<TRuleType>(obj => obj.NameMatches(pattern, useRegularExpressions),
                 obj => "does have name " + obj.Name,
-                "have full name matching \"" + pattern + "\"");
+                "have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
         }
 
 
@@ -1584,11 +1584,11 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                 "have full name \"" + fullname + "\"");
         }
 
-        public static ICondition<TRuleType> HaveFullNameMatching(string pattern)
+        public static ICondition<TRuleType> HaveFullNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            return new SimpleCondition<TRuleType>(obj => obj.FullNameMatches(pattern),
+            return new SimpleCondition<TRuleType>(obj => obj.FullNameMatches(pattern, useRegularExpressions),
                 obj => "does have full name " + obj.FullName,
-                "have full name matching \"" + pattern + "\"");
+                "have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> HaveNameStartingWith(string pattern)
@@ -2881,10 +2881,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                 "not have name \"" + name + "\"");
         }
 
-        public static ICondition<TRuleType> NotHaveNameMatching(string pattern)
+        public static ICondition<TRuleType> NotHaveNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            return new SimpleCondition<TRuleType>(obj => !obj.NameMatches(pattern), obj => "does have name " + obj.Name,
-                "not have name matching \"" + pattern + "\"");
+            return new SimpleCondition<TRuleType>(obj => !obj.NameMatches(pattern, useRegularExpressions), obj => "does have name " + obj.Name,
+                "not have name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> NotHaveFullName(string fullname)
@@ -2893,11 +2893,11 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                 obj => "does have full name " + obj.FullName, "not have full name \"" + fullname + "\"");
         }
 
-        public static ICondition<TRuleType> NotHaveFullNameMatching(string pattern)
+        public static ICondition<TRuleType> NotHaveFullNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            return new SimpleCondition<TRuleType>(obj => !obj.FullNameMatches(pattern),
+            return new SimpleCondition<TRuleType>(obj => !obj.FullNameMatches(pattern, useRegularExpressions),
                 obj => "does have full name " + obj.FullName,
-                "not have full name matching \"" + pattern + "\"");
+                "not have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> NotHaveNameStartingWith(string pattern)

--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectPredicatesDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectPredicatesDefinition.cs
@@ -1113,9 +1113,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return new SimplePredicate<T>(obj => obj.Name.Equals(name), "have name \"" + name + "\"");
         }
 
-        public static IPredicate<T> HaveNameMatching(string pattern)
+        public static IPredicate<T> HaveNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            return new SimplePredicate<T>(obj => obj.NameMatches(pattern), "have name matching \"" + pattern + "\"");
+            return new SimplePredicate<T>(obj => obj.NameMatches(pattern, useRegularExpressions),
+                "have name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
         }
 
         public static IPredicate<T> HaveFullName(string fullname)
@@ -1123,10 +1124,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return new SimplePredicate<T>(obj => obj.FullName.Equals(fullname), "have full name \"" + fullname + "\"");
         }
 
-        public static IPredicate<T> HaveFullNameMatching(string pattern)
+        public static IPredicate<T> HaveFullNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            return new SimplePredicate<T>(obj => obj.FullNameMatches(pattern),
-                "have full name matching \"" + pattern + "\"");
+            return new SimplePredicate<T>(obj => obj.FullNameMatches(pattern, useRegularExpressions),
+                "have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
         }
 
         public static IPredicate<T> HaveNameStartingWith(string pattern)
@@ -2062,10 +2063,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return new SimplePredicate<T>(obj => !obj.Name.Equals(name), "do not have name \"" + name + "\"");
         }
 
-        public static IPredicate<T> DoNotHaveNameMatching(string pattern)
+        public static IPredicate<T> DoNotHaveNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            return new SimplePredicate<T>(obj => !obj.NameMatches(pattern),
-                "do not have name matching \"" + pattern + "\"");
+            return new SimplePredicate<T>(obj => !obj.NameMatches(pattern, useRegularExpressions),
+                "do not have name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
         }
 
         public static IPredicate<T> DoNotHaveFullName(string fullname)
@@ -2074,10 +2075,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                 "do not have full name \"" + fullname + "\"");
         }
 
-        public static IPredicate<T> DoNotHaveFullNameMatching(string pattern)
+        public static IPredicate<T> DoNotHaveFullNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            return new SimplePredicate<T>(obj => !obj.FullNameMatches(pattern),
-                "do not have full name matching \"" + pattern + "\"");
+            return new SimplePredicate<T>(obj => !obj.FullNameMatches(pattern, useRegularExpressions),
+                "do not have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
         }
 
         public static IPredicate<T> DoNotHaveNameStartingWith(string pattern)

--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectsShould.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectsShould.cs
@@ -444,9 +444,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction HaveNameMatching(string pattern)
+        public TRuleTypeShouldConjunction HaveNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.HaveNameMatching(pattern));
+            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.HaveNameMatching(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -456,9 +456,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction HaveFullNameMatching(string pattern)
+        public TRuleTypeShouldConjunction HaveFullNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.HaveFullNameMatching(pattern));
+            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.HaveFullNameMatching(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -870,9 +870,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction NotHaveNameMatching(string pattern)
+        public TRuleTypeShouldConjunction NotHaveNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotHaveNameMatching(pattern));
+            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotHaveNameMatching(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -882,9 +882,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction NotHaveFullNameMatching(string pattern)
+        public TRuleTypeShouldConjunction NotHaveFullNameMatching(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotHaveFullNameMatching(pattern));
+            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotHaveFullNameMatching(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 

--- a/ArchUnitNET/Fluent/Syntax/Elements/ShouldRelateToObjectsThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ShouldRelateToObjectsThat.cs
@@ -428,10 +428,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction HaveNameMatching(string pattern)
+        public TRuleTypeShouldConjunction HaveNameMatching(string pattern, bool useRegularExpressions = false)
         {
             _ruleCreator.ContinueComplexCondition(
-                ObjectPredicatesDefinition<TReferenceType>.HaveNameMatching(pattern));
+                ObjectPredicatesDefinition<TReferenceType>.HaveNameMatching(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -441,10 +441,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction HaveFullNameMatching(string pattern)
+        public TRuleTypeShouldConjunction HaveFullNameMatching(string pattern, bool useRegularExpressions = false)
         {
             _ruleCreator.ContinueComplexCondition(
-                ObjectPredicatesDefinition<TReferenceType>.HaveFullNameMatching(pattern));
+                ObjectPredicatesDefinition<TReferenceType>.HaveFullNameMatching(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -811,10 +811,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction DoNotHaveNameMatching(string pattern)
+        public TRuleTypeShouldConjunction DoNotHaveNameMatching(string pattern, bool useRegularExpressions = false)
         {
             _ruleCreator.ContinueComplexCondition(
-                ObjectPredicatesDefinition<TReferenceType>.DoNotHaveNameMatching(pattern));
+                ObjectPredicatesDefinition<TReferenceType>.DoNotHaveNameMatching(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -825,10 +825,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction DoNotHaveFullNameMatching(string pattern)
+        public TRuleTypeShouldConjunction DoNotHaveFullNameMatching(string pattern, bool useRegularExpressions = false)
         {
             _ruleCreator.ContinueComplexCondition(
-                ObjectPredicatesDefinition<TReferenceType>.DoNotHaveFullNameMatching(pattern));
+                ObjectPredicatesDefinition<TReferenceType>.DoNotHaveFullNameMatching(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 


### PR DESCRIPTION
Only extended the public interface a bit by adding an optional parameter `useRegularExpressions` to allow regex matching instead of only `contains`.
Internals of the library remain unchanged.

Signed-off-by: Thomas De Craemer <1496708+thomasdc@users.noreply.github.com>