### PR TITLE
Testcase null attribute parameter

### DIFF
--- a/ArchUnitNETTests/ArchUnitNETTests.csproj
+++ b/ArchUnitNETTests/ArchUnitNETTests.csproj
@@ -2,9 +2,10 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>7.2</LangVersion>
         <Company>TNG Technology Consulting GmbH</Company>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <LangVersion>8</LangVersion>
+        <Features>strict</Features>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ArchUnitNETTests/Domain/AttributeArgumentTests.cs
+++ b/ArchUnitNETTests/Domain/AttributeArgumentTests.cs
@@ -270,10 +270,11 @@ namespace ArchUnitNETTests.Domain
 
     internal class AttributeWithObjectParameter : Attribute
     {
-        public AttributeWithObjectParameter(object type)
-        {
-            Type = type;
-        }
+        public AttributeWithObjectParameter(params object?[]? arguments)
+        {}
+
+        public AttributeWithObjectParameter(object? arg)
+        {}
 
         public object Type { get; }
         public object Type2;
@@ -283,7 +284,7 @@ namespace ArchUnitNETTests.Domain
     [AttributeWithStringParameters("param1_0")]
     [AttributeWithStringParameters("param1_1", Parameter2 = "param2_1")]
     [AttributeWithStringParameters("param1_2", "param2_2", Parameter3 = "param3_2")]
-    [AttributeWithObjectParameter(1)]
+    [AttributeWithObjectParameter(null)]
     internal class ClassWithMultipleAttributesWithParameters
     {
     }


### PR DESCRIPTION
The problem with this test case is that in MonoCecilAttributeExtensions.cs the wrong branch is selected and this an error is thrown that the array is not supposed to be null.