### PR TITLE
Fix attribute argument bug

### DIFF
--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
@@ -1059,7 +1059,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
 
         public static ICondition<TRuleType> HaveAnyAttributesWithArguments(IEnumerable<object> argumentValues)
         {
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             string description;
             Func<TRuleType, Architecture, string> failDescription;
             if (argumentValueList.IsNullOrEmpty())
@@ -1124,7 +1124,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description, failDescription;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "have attribute \"" + attribute + "\"";
@@ -1182,7 +1182,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description, failDescription;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "have attribute \"" + attribute.FullName + "\"";
@@ -1240,7 +1240,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description, failDescription;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "have attribute \"" + attribute.FullName + "\"";
@@ -2371,7 +2371,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
 
         public static ICondition<TRuleType> NotHaveAnyAttributesWithArguments(IEnumerable<object> argumentValues)
         {
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             string description;
             Func<TRuleType, Architecture, string> failDescription;
             if (argumentValueList.IsNullOrEmpty())
@@ -2435,7 +2435,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description, failDescription;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "not have attribute \"" + attribute + "\"";
@@ -2493,7 +2493,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description, failDescription;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "not have attribute \"" + attribute.FullName + "\"";
@@ -2551,7 +2551,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description, failDescription;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "not have attribute \"" + attribute.FullName + "\"";

--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectPredicatesDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectPredicatesDefinition.cs
@@ -673,7 +673,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
 
         public static IPredicate<T> HaveAnyAttributesWithArguments(IEnumerable<object> argumentValues)
         {
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             string description;
             if (argumentValueList.IsNullOrEmpty())
             {
@@ -718,7 +718,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "have attribute \"" + attribute + "\"";
@@ -772,7 +772,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "have attribute \"" + attribute.FullName + "\"";
@@ -826,7 +826,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "have attribute \"" + attribute.FullName + "\"";
@@ -1619,7 +1619,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
 
         public static IPredicate<T> DoNotHaveAnyAttributesWithArguments(IEnumerable<object> argumentValues)
         {
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             string description;
             if (argumentValueList.IsNullOrEmpty())
             {
@@ -1664,7 +1664,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "do not have attribute \"" + attribute + "\"";
@@ -1718,7 +1718,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "do not have attribute \"" + attribute.FullName + "\"";
@@ -1772,7 +1772,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             IEnumerable<object> argumentValues)
         {
             string description;
-            var argumentValueList = argumentValues.ToList();
+            var argumentValueList = argumentValues?.ToList() ?? new List<object> {null};
             if (argumentValueList.IsNullOrEmpty())
             {
                 description = "do not have attribute \"" + attribute.FullName + "\"";

--- a/ArchUnitNET/Loader/MonoCecilAttributeExtensions.cs
+++ b/ArchUnitNET/Loader/MonoCecilAttributeExtensions.cs
@@ -53,12 +53,12 @@ namespace ArchUnitNET.Loader
 
             type = typeFactory.GetOrCreateStubTypeInstanceFromTypeReference(argument.Type);
 
-            if (type.IsArray)
+            if (argument.Value is IEnumerable<CustomAttributeArgument> attArgEnumerable)
             {
-                value = (from arrayMember in (CustomAttributeArgument[]) argument.Value
-                        select arrayMember.Value is TypeReference tr
+                value = (from attArg in attArgEnumerable
+                        select attArg.Value is TypeReference tr
                             ? typeFactory.GetOrCreateStubTypeInstanceFromTypeReference(tr)
-                            : arrayMember.Value)
+                            : attArg.Value)
                     .ToArray();
             }
             else

--- a/ArchUnitNETTests/Domain/AttributeArgumentTests.cs
+++ b/ArchUnitNETTests/Domain/AttributeArgumentTests.cs
@@ -112,7 +112,7 @@ namespace ArchUnitNETTests.Domain
                 .HaveAnyAttributesWithNamedArguments(("Parameter2", "param2_1"), ("Parameter3", "param3_2")).Should()
                 .Exist().Check(Architecture);
             Types().That().Are(typeof(ClassWithMultipleAttributesWithParameters)).And()
-                .HaveAnyAttributesWithArguments(1).Should()
+                .HaveAnyAttributesWithArguments(null).Should()
                 .Exist().Check(Architecture);
             Types().That().Are(typeof(ClassWithTypeParameterAttribute)).And()
                 .HaveAnyAttributesWithArguments(typeof(ClassWithArrayParameterAttribute)).Should()
@@ -151,7 +151,7 @@ namespace ArchUnitNETTests.Domain
                 .Should()
                 .NotExist().Check(Architecture);
             Types().That().Are(typeof(ClassWithMultipleAttributesWithParameters)).And()
-                .DoNotHaveAnyAttributesWithArguments(1).Should()
+                .DoNotHaveAnyAttributesWithArguments(null).Should()
                 .NotExist().Check(Architecture);
             Types().That().Are(typeof(ClassWithTypeParameterAttribute)).And()
                 .DoNotHaveAnyAttributesWithArguments(typeof(ClassWithArrayParameterAttribute)).Should()
@@ -188,7 +188,7 @@ namespace ArchUnitNETTests.Domain
                 .HaveAnyAttributesWithNamedArguments(("Parameter2", "param2_1"), ("Parameter3", "param3_2"))
                 .Check(Architecture);
             Types().That().Are(typeof(ClassWithMultipleAttributesWithParameters)).Should()
-                .HaveAnyAttributesWithArguments(1).Check(Architecture);
+                .HaveAnyAttributesWithArguments(null).Check(Architecture);
             Types().That().Are(typeof(ClassWithTypeParameterAttribute)).Should()
                 .HaveAnyAttributesWithArguments(typeof(ClassWithArrayParameterAttribute)).Check(Architecture);
             Types().That().Are(typeof(ClassWithTypeParameterAttribute)).Should()
@@ -227,7 +227,7 @@ namespace ArchUnitNETTests.Domain
                 .Check(Architecture));
             Assert.Throws<FailedArchRuleException>(() => Types().That()
                 .Are(typeof(ClassWithMultipleAttributesWithParameters)).Should()
-                .NotHaveAnyAttributesWithArguments(1).Check(Architecture));
+                .NotHaveAnyAttributesWithArguments(null).Check(Architecture));
             Assert.Throws<FailedArchRuleException>(() => Types().That().Are(typeof(ClassWithTypeParameterAttribute))
                 .Should()
                 .NotHaveAnyAttributesWithArguments(typeof(ClassWithArrayParameterAttribute)).Check(Architecture));
@@ -270,9 +270,12 @@ namespace ArchUnitNETTests.Domain
 
     internal class AttributeWithObjectParameter : Attribute
     {
-        public AttributeWithObjectParameter(object type)
+        public AttributeWithObjectParameter(params object[] arguments)
         {
-            Type = type;
+        }
+
+        public AttributeWithObjectParameter(object arg)
+        {
         }
 
         public object Type { get; }
@@ -283,7 +286,7 @@ namespace ArchUnitNETTests.Domain
     [AttributeWithStringParameters("param1_0")]
     [AttributeWithStringParameters("param1_1", Parameter2 = "param2_1")]
     [AttributeWithStringParameters("param1_2", "param2_2", Parameter3 = "param3_2")]
-    [AttributeWithObjectParameter(1)]
+    [AttributeWithObjectParameter(null)]
     internal class ClassWithMultipleAttributesWithParameters
     {
     }


### PR DESCRIPTION
Fix a bug where Attributes with null as argument could lead to an ArgumentNullException during build of the architecture.
This implements and fixes the testcase from PR #110