### PR TITLE
refractor circular dependencies between Domain, Fluent and Loader

### DIFF
--- a/ArchUnitNET/Domain/IHasDescription.cs
+++ b/ArchUnitNET/Domain/IHasDescription.cs
@@ -4,7 +4,7 @@
 // 
 // 	SPDX-License-Identifier: Apache-2.0
 
-namespace ArchUnitNET.Fluent
+namespace ArchUnitNET.Domain
 {
     public interface IHasDescription
     {

--- a/ArchUnitNET/Domain/IObjectProvider.cs
+++ b/ArchUnitNET/Domain/IObjectProvider.cs
@@ -5,9 +5,8 @@
 // 	SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
-using ArchUnitNET.Domain;
 
-namespace ArchUnitNET.Fluent
+namespace ArchUnitNET.Domain
 {
     public interface IObjectProvider<out T> : IHasDescription where T : ICanBeAnalyzed
     {

--- a/ArchUnitNET/Domain/MethodMemberInstance.cs
+++ b/ArchUnitNET/Domain/MethodMemberInstance.cs
@@ -7,9 +7,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using ArchUnitNET.Domain;
 
-namespace ArchUnitNET.Loader
+namespace ArchUnitNET.Domain
 {
     public class MethodMemberInstance : ITypeInstance<IType>
     {

--- a/ArchUnitNET/Fluent/Extensions/SyntaxElementExtensions.cs
+++ b/ArchUnitNET/Fluent/Extensions/SyntaxElementExtensions.cs
@@ -4,6 +4,8 @@
 // 
 // 	SPDX-License-Identifier: Apache-2.0
 
+using ArchUnitNET.Domain;
+
 namespace ArchUnitNET.Fluent.Extensions
 {
     public static class SyntaxElementExtensions

--- a/ArchUnitNET/Fluent/LogicalConjunction.cs
+++ b/ArchUnitNET/Fluent/LogicalConjunction.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using ArchUnitNET.Domain;
 
 namespace ArchUnitNET.Fluent
 {

--- a/ArchUnitNET/Fluent/Slices/SliceIdentifier.cs
+++ b/ArchUnitNET/Fluent/Slices/SliceIdentifier.cs
@@ -5,6 +5,7 @@
 // 	SPDX-License-Identifier: Apache-2.0
 // 
 
+using ArchUnitNET.Domain;
 using ArchUnitNET.Fluent.Freeze;
 
 namespace ArchUnitNET.Fluent.Slices

--- a/ArchUnitNETTests/ArchitectureTests/ArchUnitArchitectureTests.cs
+++ b/ArchUnitNETTests/ArchitectureTests/ArchUnitArchitectureTests.cs
@@ -7,6 +7,7 @@
 
 using ArchUnitNET.Domain;
 using ArchUnitNET.Fluent;
+using ArchUnitNET.Fluent.Slices;
 using ArchUnitNET.Loader;
 using ArchUnitNET.xUnit;
 using Xunit;
@@ -23,11 +24,19 @@ namespace ArchUnitNETTests.ArchitectureTests
         private readonly Architecture _architecture =
             new ArchLoader().LoadAssembly(typeof(Architecture).Assembly).Build();
 
-        [Fact(Skip = "Need more refactoring")]
-        public void DomainHasNoDependencyOnFluentAndLoader()
+        [Fact]
+        public void DomainHasNoDependencyOnFluent()
         {
             Types().That().ResideInNamespace(DomainNamespace)
-                .Should().NotDependOnAny(new[] {LoaderNamespace, FluentNamespace})
+                .Should().NotDependOnAny(FluentNamespace)
+                .Check(_architecture);
+        }
+
+        [Fact]
+        public void DomainHasNoDependencyOnLoader()
+        {
+            Types().That().ResideInNamespace(DomainNamespace)
+                .Should().NotDependOnAny(LoaderNamespace)
                 .Check(_architecture);
         }
 
@@ -45,6 +54,12 @@ namespace ArchUnitNETTests.ArchitectureTests
             Types().That().ResideInNamespace(FluentNamespace)
                 .Should().NotDependOnAny(LoaderNamespace)
                 .Check(_architecture);
+        }
+
+        [Fact]
+        public void NoCircularDependencies()
+        {
+            SliceRuleDefinition.Slices().Matching("ArchUnitNET.(*)").Should().BeFreeOfCycles().Check(_architecture);
         }
     }
 }


### PR DESCRIPTION
this removes the circular dependencies pointed out in the first test of #112 