### PR TITLE
Change matching of name and fullname patterns to exact match by default

### DIFF
--- a/ArchUnitNET/Domain/Extensions/NamingExtensions.cs
+++ b/ArchUnitNET/Domain/Extensions/NamingExtensions.cs
@@ -5,6 +5,7 @@
 // 	SPDX-License-Identifier: Apache-2.0
 // 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -37,7 +38,7 @@ namespace ArchUnitNET.Domain.Extensions
                 return pattern != null && Regex.IsMatch(cls.Name, pattern);
             }
 
-            return cls.NameContains(pattern);
+            return string.Equals(cls.Name, pattern, StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool FullNameMatches(this IHasName cls, string pattern, bool useRegularExpressions = false)
@@ -47,7 +48,7 @@ namespace ArchUnitNET.Domain.Extensions
                 return pattern != null && Regex.IsMatch(cls.FullName, pattern);
             }
 
-            return cls.FullNameContains(pattern);
+            return string.Equals(cls.FullName, pattern, StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool FullNameContains(this IHasName cls, string pattern)

--- a/ArchUnitNET/Domain/Extensions/TypeExtensions.cs
+++ b/ArchUnitNET/Domain/Extensions/TypeExtensions.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using ArchUnitNET.Domain.Dependencies;
 
 namespace ArchUnitNET.Domain.Extensions
@@ -30,7 +29,7 @@ namespace ArchUnitNET.Domain.Extensions
             switch (type)
             {
                 case Interface intf:
-                    return intf.ImplementedInterfaces.Concat(new[] { intf });
+                    return intf.ImplementedInterfaces.Concat(new[] {intf});
                 case Class cls:
                     return cls.InheritedClasses.Concat(new[] {cls}).Concat(cls.ImplementedInterfaces);
                 case Struct str:

--- a/ArchUnitNET/Fluent/Syntax/Elements/GivenObjectsThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/GivenObjectsThat.cs
@@ -382,27 +382,15 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TGivenRuleTypeConjunction HaveName(string name)
+        public TGivenRuleTypeConjunction HaveName(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.HaveName(name));
+            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.HaveName(pattern, useRegularExpressions));
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TGivenRuleTypeConjunction HaveNameMatching(string pattern, bool useRegularExpressions = false)
+        public TGivenRuleTypeConjunction HaveFullName(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.HaveNameMatching(pattern, useRegularExpressions));
-            return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TGivenRuleTypeConjunction HaveFullName(string fullname)
-        {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.HaveFullName(fullname));
-            return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TGivenRuleTypeConjunction HaveFullNameMatching(string pattern, bool useRegularExpressions = false)
-        {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.HaveFullNameMatching(pattern, useRegularExpressions));
+            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.HaveFullName(pattern, useRegularExpressions));
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -732,27 +720,15 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TGivenRuleTypeConjunction DoNotHaveName(string name)
+        public TGivenRuleTypeConjunction DoNotHaveName(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.DoNotHaveName(name));
+            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.DoNotHaveName(pattern, useRegularExpressions));
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TGivenRuleTypeConjunction DoNotHaveNameMatching(string pattern, bool useRegularExpressions = false)
+        public TGivenRuleTypeConjunction DoNotHaveFullName(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.DoNotHaveNameMatching(pattern, useRegularExpressions));
-            return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TGivenRuleTypeConjunction DoNotHaveFullName(string fullname)
-        {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.DoNotHaveFullName(fullname));
-            return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TGivenRuleTypeConjunction DoNotHaveFullNameMatching(string pattern, bool useRegularExpressions = false)
-        {
-            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.DoNotHaveFullNameMatching(pattern, useRegularExpressions));
+            _ruleCreator.AddPredicate(ObjectPredicatesDefinition<TRuleType>.DoNotHaveFullName(pattern, useRegularExpressions));
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
 

--- a/ArchUnitNET/Fluent/Syntax/Elements/IObjectConditions.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/IObjectConditions.cs
@@ -72,10 +72,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         TReturnType HaveAttributeWithNamedArguments(Attribute attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
         TReturnType HaveAttributeWithNamedArguments(Type attribute, IEnumerable<(string,object)> attributeArguments);
         TReturnType HaveAttributeWithNamedArguments(Type attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
-        TReturnType HaveName(string name);
-        TReturnType HaveNameMatching(string pattern, bool useRegularExpressions = false);
-        TReturnType HaveFullName(string fullname);
-        TReturnType HaveFullNameMatching(string pattern, bool useRegularExpressions = false);
+        TReturnType HaveName(string pattern, bool useRegularExpressions = false);
+        TReturnType HaveFullName(string pattern, bool useRegularExpressions = false);
         TReturnType HaveNameStartingWith(string pattern);
         TReturnType HaveNameEndingWith(string pattern);
         TReturnType HaveNameContaining(string pattern);
@@ -128,10 +126,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         TReturnType NotHaveAttributeWithNamedArguments(Attribute attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
         TReturnType NotHaveAttributeWithNamedArguments(Type attribute, IEnumerable<(string,object)> attributeArguments);
         TReturnType NotHaveAttributeWithNamedArguments(Type attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
-        TReturnType NotHaveName(string name);
-        TReturnType NotHaveNameMatching(string pattern, bool useRegularExpressions = false);
-        TReturnType NotHaveFullName(string fullname);
-        TReturnType NotHaveFullNameMatching(string pattern, bool useRegularExpressions = false);
+        TReturnType NotHaveName(string pattern, bool useRegularExpressions = false);
+        TReturnType NotHaveFullName(string pattern, bool useRegularExpressions = false);
         TReturnType NotHaveNameStartingWith(string pattern);
         TReturnType NotHaveNameEndingWith(string pattern);
         TReturnType NotHaveNameContaining(string pattern);

--- a/ArchUnitNET/Fluent/Syntax/Elements/IObjectPredicates.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/IObjectPredicates.cs
@@ -70,10 +70,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         TReturnType HaveAttributeWithNamedArguments(Attribute attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
         TReturnType HaveAttributeWithNamedArguments(Type attribute, IEnumerable<(string,object)> attributeArguments);
         TReturnType HaveAttributeWithNamedArguments(Type attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
-        TReturnType HaveName(string name);
-        TReturnType HaveNameMatching(string pattern, bool useRegularExpressions = false);
-        TReturnType HaveFullName(string fullname);
-        TReturnType HaveFullNameMatching(string pattern, bool useRegularExpressions = false);
+        TReturnType HaveName(string pattern, bool useRegularExpressions = false);
+        TReturnType HaveFullName(string pattern, bool useRegularExpressions = false);
         TReturnType HaveNameStartingWith(string pattern);
         TReturnType HaveNameEndingWith(string pattern);
         TReturnType HaveNameContaining(string pattern);
@@ -129,10 +127,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         TReturnType DoNotHaveAttributeWithNamedArguments(Attribute attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
         TReturnType DoNotHaveAttributeWithNamedArguments(Type attribute, IEnumerable<(string,object)> attributeArguments);
         TReturnType DoNotHaveAttributeWithNamedArguments(Type attribute, (string,object) firstAttributeArgument, params (string,object)[] moreAttributeArguments);
-        TReturnType DoNotHaveName(string name);
-        TReturnType DoNotHaveNameMatching(string pattern, bool useRegularExpressions = false);
-        TReturnType DoNotHaveFullName(string fullname);
-        TReturnType DoNotHaveFullNameMatching(string pattern, bool useRegularExpressions = false);
+        TReturnType DoNotHaveName(string pattern, bool useRegularExpressions = false);
+        TReturnType DoNotHaveFullName(string pattern, bool useRegularExpressions = false);
         TReturnType DoNotHaveNameStartingWith(string pattern);
         TReturnType DoNotHaveNameEndingWith(string pattern);
         TReturnType DoNotHaveNameContaining(string pattern);

--- a/ArchUnitNET/Fluent/Syntax/Elements/Members/MemberConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Members/MemberConditionsDefinition.cs
@@ -19,7 +19,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members
         {
             return new SimpleCondition<TRuleType>(member => member.IsDeclaredIn(pattern, useRegularExpressions),
                 member => "is declared in " + member.DeclaringType.FullName,
-                "be declared in types with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "be declared in types with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -42,8 +42,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(obj => !obj.Equals(firstPattern)).Distinct().Aggregate(
-                    "be declared in types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "be declared in types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -185,8 +185,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members
         {
             return new SimpleCondition<TRuleType>(member => !member.IsDeclaredIn(pattern, useRegularExpressions),
                 member => "is declared in " + member.DeclaringType.FullName,
-                "not be declared in types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "not be declared in types with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> NotBeDeclaredIn(IEnumerable<string> patterns,
@@ -208,8 +208,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(obj => !obj.Equals(firstPattern)).Distinct().Aggregate(
-                    "not be declared in types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "not be declared in types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 

--- a/ArchUnitNET/Fluent/Syntax/Elements/Members/MemberPredicatesDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Members/MemberPredicatesDefinition.cs
@@ -18,7 +18,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members
         public static IPredicate<T> AreDeclaredIn(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(member => member.IsDeclaredIn(pattern, useRegularExpressions),
-                "are declared in types with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "are declared in types with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -40,8 +40,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(obj => !obj.Equals(firstPattern)).Distinct().Aggregate(
-                    "are declared in types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    "are declared in types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimplePredicate<T>(Condition, description);
@@ -148,8 +148,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members
         public static IPredicate<T> AreNotDeclaredIn(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(member => !member.IsDeclaredIn(pattern, useRegularExpressions),
-                "are not declared in types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "are not declared in types with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static IPredicate<T> AreNotDeclaredIn(IEnumerable<string> patterns, bool useRegularExpressions = false)
@@ -170,8 +170,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(obj => !obj.Equals(firstPattern)).Distinct().Aggregate(
-                    "are not declared in types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    "are not declared in types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimplePredicate<T>(Condition, description);

--- a/ArchUnitNET/Fluent/Syntax/Elements/Members/MethodMembers/MethodMemberConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Members/MethodMembers/MethodMemberConditionsDefinition.cs
@@ -30,9 +30,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
         {
             return new SimpleCondition<MethodMember>(
                 member => member.IsCalledBy(pattern, useRegularExpressions),
-                "be called by types with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "be called by types with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"",
-                "is called by a type with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "is called by a type with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -57,12 +57,12 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
-                    "be called by types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "be called by types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
                 failDescription = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
-                    "is not called by types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "is not called by types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -214,11 +214,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
             return new SimpleCondition<MethodMember>(
                 member => member.HasDependencyInMethodBodyTo(pattern, useRegularExpressions),
                 "have dependencies in method body to types with full name " +
-                (useRegularExpressions ? "matching" : "containing") + " \"" +
-                pattern + "\"",
+                (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"",
                 "does not have dependencies in method body to a type with full name " +
-                (useRegularExpressions ? "matching" : "containing") + " \"" +
-                pattern + "\"");
+                (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static ICondition<MethodMember> HaveDependencyInMethodBodyTo(IEnumerable<string> patterns,
@@ -243,13 +241,11 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
                     "have dependencies in method body to types with full name " +
-                    (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    (useRegularExpressions ? "matching " : "") + "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
                 failDescription = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
                     "does not have dependencies in method body to types with full name " +
-                    (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    (useRegularExpressions ? "matching " : "") + "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -401,12 +397,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
         public static ICondition<MethodMember> HaveReturnType(string pattern, bool useRegularExpressions = false)
         {
             var description = "have return type with full name " +
-                              (useRegularExpressions ? "matching" : "containing") + " \"" +
-                              pattern + "\"";
+                              (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"";
 
             var failDescription = "does not have return type with full name " +
-                                  (useRegularExpressions ? "matching" : "containing") + " \"" +
-                                  pattern + "\"";
+                                  (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"";
 
             return new SimpleCondition<MethodMember>(
                 member => member.ReturnType.FullNameMatches(pattern, useRegularExpressions), description,
@@ -418,11 +412,11 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
         {
             var patternsArray = patterns.ToArray();
             var description = "have return type with full name " +
-                              (useRegularExpressions ? "matching" : "containing") + " \"" +
+                              (useRegularExpressions ? "matching " : "") + "\"" +
                               string.Join("\" or \"", patternsArray) + "\"";
 
             var failDescription = "does not have return type with full name " +
-                                  (useRegularExpressions ? "matching" : "containing") + " \"" +
+                                  (useRegularExpressions ? "matching " : "") + "\"" +
                                   string.Join("\" or \"", patternsArray) + "\"";
 
             bool Condition(MethodMember member)
@@ -537,7 +531,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
             }
 
             return new SimpleCondition<MethodMember>(Condition,
-                "not be called by types with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "not be called by types with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -562,12 +556,12 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
-                    "not be called by types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "not be called by types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
                 failDescription = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
-                    "is called by types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "is called by types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -735,7 +729,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
 
             return new SimpleCondition<MethodMember>(Condition,
                 "not have dependencies in method body to types with full name " +
-                (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static ICondition<MethodMember> NotHaveDependencyInMethodBodyTo(IEnumerable<string> patterns,
@@ -761,13 +755,11 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
                     "not have dependencies in method body to types with full name " +
-                    (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    (useRegularExpressions ? "matching " : "") + "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
                 failDescription = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
                     "does have dependencies in method body to types with full name " +
-                    (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    (useRegularExpressions ? "matching " : "") + "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -920,12 +912,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
         public static ICondition<MethodMember> NotHaveReturnType(string pattern, bool useRegularExpressions = false)
         {
             var description = "not have return type with full name " +
-                              (useRegularExpressions ? "matching" : "containing") + " \"" +
-                              pattern + "\"";
+                              (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"";
 
             var failDescription = "does have return type with full name " +
-                                  (useRegularExpressions ? "matching" : "containing") + " \"" +
-                                  pattern + "\"";
+                                  (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"";
 
             return new SimpleCondition<MethodMember>(
                 member => !member.ReturnType.FullNameMatches(pattern, useRegularExpressions), description,
@@ -937,11 +927,11 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
         {
             var patternsArray = patterns.ToArray();
             var description = "not have return type with full name " +
-                              (useRegularExpressions ? "matching" : "containing") + " \"" +
+                              (useRegularExpressions ? "matching " : "") + "\"" +
                               string.Join("\" or \"", patternsArray) + "\"";
 
             var failDescription = "does have return type with full name " +
-                                  (useRegularExpressions ? "matching" : "containing") + " \"" +
+                                  (useRegularExpressions ? "matching " : "") + "\"" +
                                   string.Join("\" or \"", patternsArray) + "\"";
 
             bool Condition(MethodMember member)

--- a/ArchUnitNET/Fluent/Syntax/Elements/Members/MethodMembers/MethodMemberPredicatesDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Members/MethodMembers/MethodMemberPredicatesDefinition.cs
@@ -29,7 +29,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
         {
             return new SimplePredicate<MethodMember>(
                 member => member.IsCalledBy(pattern, useRegularExpressions),
-                "are called by types with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "are called by types with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -52,8 +52,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
-                    "are called by types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    "are called by types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimplePredicate<MethodMember>(Condition, description);
@@ -142,7 +142,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
             return new SimplePredicate<MethodMember>(
                 member => member.HasDependencyInMethodBodyTo(pattern, useRegularExpressions),
                 "have dependencies in method body to types with full name " +
-                (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static IPredicate<MethodMember> HaveDependencyInMethodBodyTo(IEnumerable<string> patterns,
@@ -165,8 +165,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
                     "have dependencies in method body to types with full name " +
-                    (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimplePredicate<MethodMember>(Condition, description);
@@ -260,7 +260,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
             return new SimplePredicate<MethodMember>(
                 member => member.ReturnType.FullNameMatches(pattern, useRegularExpressions),
                 "have return type with full name " +
-                (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static IPredicate<MethodMember> HaveReturnType(IEnumerable<string> patterns,
@@ -268,7 +268,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
         {
             var patternsArray = patterns.ToArray();
             var description = "have return type with full name " +
-                              (useRegularExpressions ? "matching" : "containing") + " \"" +
+                              (useRegularExpressions ? "matching " : "") + "\"" +
                               string.Join("\" or \"", patternsArray) + "\"";
 
             return new SimplePredicate<MethodMember>(
@@ -342,9 +342,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
         {
             return new SimplePredicate<MethodMember>(
                 member => !member.IsCalledBy(pattern, useRegularExpressions),
-                "are not called by types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" +
-                pattern + "\"");
+                "are not called by types with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static IPredicate<MethodMember> AreNotCalledBy(IEnumerable<string> patterns,
@@ -366,8 +365,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
-                    "are not called by types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    "are not called by types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimplePredicate<MethodMember>(Condition, description);
@@ -456,7 +455,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
             return new SimplePredicate<MethodMember>(
                 member => !member.HasDependencyInMethodBodyTo(pattern, useRegularExpressions),
                 "do not have dependencies in method body to types with full name " +
-                (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static IPredicate<MethodMember> DoNotHaveDependencyInMethodBodyTo(IEnumerable<string> patterns,
@@ -480,8 +479,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
                     "do not have dependencies in method body to types with full name " +
-                    (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimplePredicate<MethodMember>(Condition, description);
@@ -577,7 +576,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
             return new SimplePredicate<MethodMember>(
                 member => !member.ReturnType.FullNameMatches(pattern, useRegularExpressions),
                 "do not have return type with full name " +
-                (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static IPredicate<MethodMember> DoNotHaveReturnType(IEnumerable<string> patterns,
@@ -585,7 +584,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members.MethodMembers
         {
             var patternsArray = patterns.ToArray();
             var description = "do not have return type with full name " +
-                              (useRegularExpressions ? "matching" : "containing") + " \"" +
+                              (useRegularExpressions ? "matching " : "") + "\"" +
                               string.Join("\" or \"", patternsArray) + "\"";
 
             return new SimplePredicate<MethodMember>(

--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
@@ -28,8 +28,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         {
             return new SimpleCondition<TRuleType>(
                 obj => obj.FullNameMatches(pattern, useRegularExpressions),
-                "have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"",
-                "does not have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern +
+                "have full name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"",
+                "does not have full name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern +
                 "\"");
         }
 
@@ -47,12 +47,12 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "have full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "have full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
                 failDescription = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "does not have full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "does not have full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -135,10 +135,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         {
             return new SimpleCondition<TRuleType>(
                 obj => obj.CallsMethod(pattern, useRegularExpressions),
-                "calls any method with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "calls any method with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"",
-                "does not call any method with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "does not call any method with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> CallAny(IEnumerable<string> patterns,
@@ -162,12 +162,12 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "calls any method with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "calls any method with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
                 failDescription = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "does not call any methods with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "does not call any methods with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -260,10 +260,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         {
             return new SimpleCondition<TRuleType>(
                 obj => obj.DependsOn(pattern, useRegularExpressions),
-                "depend on any types with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "depend on any types with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"",
-                "does not depend on any type with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "does not depend on any type with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> DependOnAny(IEnumerable<string> patterns,
@@ -289,12 +289,12 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "depend on any types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "depend on any types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
                 failDescription = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "does not depend any types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "does not depend any types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -466,7 +466,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             }
 
             return new SimpleCondition<TRuleType>(Condition,
-                "only depend on types with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "only depend on types with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -500,8 +500,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "only depend on types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    "only depend on types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimpleCondition<TRuleType>(Condition, description);
@@ -648,10 +648,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         {
             return new SimpleCondition<TRuleType>(
                 obj => obj.HasAttribute(pattern, useRegularExpressions),
-                "have any attribute with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "have any attribute with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"",
-                "does not have any attribute with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "does not have any attribute with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> HaveAnyAttributes(IEnumerable<string> patterns,
@@ -676,13 +676,13 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "have any attribute with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "have any attribute with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
                 failDescription = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
                     "does not have any attribute with full name " +
-                    (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -817,10 +817,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         {
             return new SimpleCondition<TRuleType>(
                 obj => obj.OnlyHasAttributes(pattern, useRegularExpressions),
-                "only have attributes with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "only have attributes with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"",
-                "does not only have attributes with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "does not only have attributes with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> OnlyHaveAttributes(IEnumerable<string> patterns,
@@ -845,13 +845,13 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "only have attributes with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "only have attributes with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " and \"" + pattern + "\"");
                 failDescription = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
                     "does not only have attributes with full name " +
-                    (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -1563,32 +1563,18 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return new ArchitectureCondition<TRuleType>(Condition, failDescription, description);
         }
 
-        public static ICondition<TRuleType> HaveName(string name)
-        {
-            return new SimpleCondition<TRuleType>(
-                obj => obj.Name.Equals(name), obj => "does have name " + obj.Name, "have name \"" + name + "\"");
-        }
-
-        public static SimpleCondition<TRuleType> HaveNameMatching(string pattern, bool useRegularExpressions = false)
+        public static ICondition<TRuleType> HaveName(string pattern, bool useRegularExpressions = false)
         {
             return new SimpleCondition<TRuleType>(obj => obj.NameMatches(pattern, useRegularExpressions),
                 obj => "does have name " + obj.Name,
-                "have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                "have full name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
-
-        public static ICondition<TRuleType> HaveFullName(string fullname)
-        {
-            return new SimpleCondition<TRuleType>(
-                obj => obj.FullName.Equals(fullname), obj => "does have full name " + obj.FullName,
-                "have full name \"" + fullname + "\"");
-        }
-
-        public static ICondition<TRuleType> HaveFullNameMatching(string pattern, bool useRegularExpressions = false)
+        public static ICondition<TRuleType> HaveFullName(string pattern, bool useRegularExpressions = false)
         {
             return new SimpleCondition<TRuleType>(obj => obj.FullNameMatches(pattern, useRegularExpressions),
                 obj => "does have full name " + obj.FullName,
-                "have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                "have full name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> HaveNameStartingWith(string pattern)
@@ -1699,7 +1685,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return new SimpleCondition<TRuleType>(
                 obj => !obj.FullNameMatches(pattern, useRegularExpressions),
                 obj => "is " + obj.FullName,
-                "not have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                "not have full name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> NotBe(IEnumerable<string> patterns, bool useRegularExpressions = false)
@@ -1714,8 +1700,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "not have full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    "not have full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimpleCondition<TRuleType>(
@@ -1805,8 +1791,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             }
 
             return new SimpleCondition<TRuleType>(Condition,
-                "not call any method with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "not call any method with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> NotCallAny(IEnumerable<string> patterns,
@@ -1839,8 +1825,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "not call methods with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    "not call methods with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimpleCondition<TRuleType>(Condition, description);
@@ -1948,8 +1934,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             }
 
             return new SimpleCondition<TRuleType>(Condition,
-                "not depend on any types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "not depend on any types with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> NotDependOnAny(IEnumerable<string> patterns,
@@ -1982,8 +1968,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "not depend on types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    "not depend on types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimpleCondition<TRuleType>(Condition, description);
@@ -2127,10 +2113,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         {
             return new SimpleCondition<TRuleType>(
                 obj => !obj.HasAttribute(pattern, useRegularExpressions),
-                "not have any attribute with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "not have any attribute with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"",
-                "does have any attribute with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "does have any attribute with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> NotHaveAnyAttributes(IEnumerable<string> patterns,
@@ -2155,13 +2141,13 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "not have any attribute with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "not have any attribute with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
                 failDescription = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
                     "does have any attribute with full name " +
-                    (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -2875,29 +2861,17 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return new ArchitectureCondition<TRuleType>(Condition, failDescription, description);
         }
 
-        public static ICondition<TRuleType> NotHaveName(string name)
-        {
-            return new SimpleCondition<TRuleType>(obj => !obj.Name.Equals(name), obj => "does have name " + obj.Name,
-                "not have name \"" + name + "\"");
-        }
-
-        public static ICondition<TRuleType> NotHaveNameMatching(string pattern, bool useRegularExpressions = false)
+        public static ICondition<TRuleType> NotHaveName(string pattern, bool useRegularExpressions = false)
         {
             return new SimpleCondition<TRuleType>(obj => !obj.NameMatches(pattern, useRegularExpressions), obj => "does have name " + obj.Name,
-                "not have name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                "not have name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
-        public static ICondition<TRuleType> NotHaveFullName(string fullname)
-        {
-            return new SimpleCondition<TRuleType>(obj => !obj.FullName.Equals(fullname),
-                obj => "does have full name " + obj.FullName, "not have full name \"" + fullname + "\"");
-        }
-
-        public static ICondition<TRuleType> NotHaveFullNameMatching(string pattern, bool useRegularExpressions = false)
+        public static ICondition<TRuleType> NotHaveFullName(string pattern, bool useRegularExpressions = false)
         {
             return new SimpleCondition<TRuleType>(obj => !obj.FullNameMatches(pattern, useRegularExpressions),
                 obj => "does have full name " + obj.FullName,
-                "not have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                "not have full name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> NotHaveNameStartingWith(string pattern)

--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectPredicatesDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectPredicatesDefinition.cs
@@ -21,7 +21,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         public static IPredicate<T> Are(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => obj.FullNameMatches(pattern, useRegularExpressions),
-                "have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                "have full name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static IPredicate<T> Are(IEnumerable<string> patterns, bool useRegularExpressions = false)
@@ -36,7 +36,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                    "have full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                     firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -84,7 +84,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         public static IPredicate<T> CallAny(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => obj.CallsMethod(pattern, useRegularExpressions),
-                "calls any method with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "calls any method with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -106,8 +106,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "call any method with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" +
+                    "call any method with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" +
                     firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -161,7 +161,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         public static IPredicate<T> DependOnAny(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => obj.DependsOn(pattern, useRegularExpressions),
-                "depend on any types with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "depend on any types with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -184,8 +184,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "depend on any types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" +
+                    "depend on any types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" +
                     firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -277,7 +277,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         public static IPredicate<T> OnlyDependOn(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => obj.OnlyDependsOn(pattern, useRegularExpressions),
-                "only depend on types with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "only depend on types with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -300,8 +300,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "only depend on types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" +
+                    "only depend on types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" +
                     firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -388,7 +388,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         public static IPredicate<T> HaveAnyAttributes(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => obj.HasAttribute(pattern, useRegularExpressions),
-                "have any attribute with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "have any attribute with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -411,8 +411,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "have any attribute with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" +
+                    "have any attribute with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" +
                     firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -499,7 +499,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         public static IPredicate<T> OnlyHaveAttributes(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => obj.OnlyHasAttributes(pattern, useRegularExpressions),
-                "only have attributes with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "only have attributes with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -522,8 +522,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "only have attributes with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" +
+                    "only have attributes with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" +
                     firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -1108,26 +1108,16 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return new ArchitecturePredicate<T>(Predicate, description);
         }
 
-        public static IPredicate<T> HaveName(string name)
-        {
-            return new SimplePredicate<T>(obj => obj.Name.Equals(name), "have name \"" + name + "\"");
-        }
-
-        public static IPredicate<T> HaveNameMatching(string pattern, bool useRegularExpressions = false)
+        public static IPredicate<T> HaveName(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => obj.NameMatches(pattern, useRegularExpressions),
-                "have name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                "have name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
-        public static IPredicate<T> HaveFullName(string fullname)
-        {
-            return new SimplePredicate<T>(obj => obj.FullName.Equals(fullname), "have full name \"" + fullname + "\"");
-        }
-
-        public static IPredicate<T> HaveFullNameMatching(string pattern, bool useRegularExpressions = false)
+        public static IPredicate<T> HaveFullName(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => obj.FullNameMatches(pattern, useRegularExpressions),
-                "have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                "have full name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static IPredicate<T> HaveNameStartingWith(string pattern)
@@ -1190,7 +1180,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         public static IPredicate<T> AreNot(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => !obj.FullNameMatches(pattern, useRegularExpressions),
-                "do not have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern +
+                "do not have full name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern +
                 "\"");
         }
 
@@ -1206,7 +1196,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "do not have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                    "do not have full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                     firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -1254,8 +1244,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         public static IPredicate<T> DoNotCallAny(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => !obj.CallsMethod(pattern, useRegularExpressions),
-                "do not call any methods with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "do not call any methods with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static IPredicate<T> DoNotCallAny(IEnumerable<string> patterns, bool useRegularExpressions = false)
@@ -1276,8 +1266,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "do not call any methods with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" +
+                    "do not call any methods with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" +
                     firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -1331,8 +1321,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         public static IPredicate<T> DoNotDependOnAny(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => !obj.DependsOn(pattern, useRegularExpressions),
-                "do not depend on any types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "do not depend on any types with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static IPredicate<T> DoNotDependOnAny(IEnumerable<string> patterns, bool useRegularExpressions = false)
@@ -1354,8 +1344,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "do not depend on any types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" +
+                    "do not depend on any types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" +
                     firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -1442,8 +1432,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         public static IPredicate<T> DoNotHaveAnyAttributes(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => !obj.HasAttribute(pattern, useRegularExpressions),
-                "do not have any attribute with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" +
+                "do not have any attribute with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" +
                 pattern + "\"");
         }
 
@@ -1467,8 +1457,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(pattern => !pattern.Equals(firstPattern)).Distinct().Aggregate(
-                    "do not have any attribute with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" +
+                    "do not have any attribute with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" +
                     firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -2058,27 +2048,16 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return new ArchitecturePredicate<T>(Predicate, description);
         }
 
-        public static IPredicate<T> DoNotHaveName(string name)
-        {
-            return new SimplePredicate<T>(obj => !obj.Name.Equals(name), "do not have name \"" + name + "\"");
-        }
-
-        public static IPredicate<T> DoNotHaveNameMatching(string pattern, bool useRegularExpressions = false)
+        public static IPredicate<T> DoNotHaveName(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => !obj.NameMatches(pattern, useRegularExpressions),
-                "do not have name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                "do not have name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
-        public static IPredicate<T> DoNotHaveFullName(string fullname)
-        {
-            return new SimplePredicate<T>(obj => !obj.FullName.Equals(fullname),
-                "do not have full name \"" + fullname + "\"");
-        }
-
-        public static IPredicate<T> DoNotHaveFullNameMatching(string pattern, bool useRegularExpressions = false)
+        public static IPredicate<T> DoNotHaveFullName(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(obj => !obj.FullNameMatches(pattern, useRegularExpressions),
-                "do not have full name " + (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"");
+                "do not have full name " + (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"");
         }
 
         public static IPredicate<T> DoNotHaveNameStartingWith(string pattern)

--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectsShould.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectsShould.cs
@@ -438,27 +438,15 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction HaveName(string name)
+        public TRuleTypeShouldConjunction HaveName(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.HaveName(name));
+            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.HaveName(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction HaveNameMatching(string pattern, bool useRegularExpressions = false)
+        public TRuleTypeShouldConjunction HaveFullName(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.HaveNameMatching(pattern, useRegularExpressions));
-            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TRuleTypeShouldConjunction HaveFullName(string fullname)
-        {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.HaveFullName(fullname));
-            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TRuleTypeShouldConjunction HaveFullNameMatching(string pattern, bool useRegularExpressions = false)
-        {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.HaveFullNameMatching(pattern, useRegularExpressions));
+            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.HaveFullName(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -864,27 +852,15 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction NotHaveName(string name)
+        public TRuleTypeShouldConjunction NotHaveName(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotHaveName(name));
+            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotHaveName(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction NotHaveNameMatching(string pattern, bool useRegularExpressions = false)
+        public TRuleTypeShouldConjunction NotHaveFullName(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotHaveNameMatching(pattern, useRegularExpressions));
-            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TRuleTypeShouldConjunction NotHaveFullName(string fullname)
-        {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotHaveFullName(fullname));
-            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TRuleTypeShouldConjunction NotHaveFullNameMatching(string pattern, bool useRegularExpressions = false)
-        {
-            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotHaveFullNameMatching(pattern, useRegularExpressions));
+            _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotHaveFullName(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 

--- a/ArchUnitNET/Fluent/Syntax/Elements/ShouldRelateToObjectsThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ShouldRelateToObjectsThat.cs
@@ -422,29 +422,17 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction HaveName(string name)
-        {
-            _ruleCreator.ContinueComplexCondition(ObjectPredicatesDefinition<TReferenceType>.HaveName(name));
-            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TRuleTypeShouldConjunction HaveNameMatching(string pattern, bool useRegularExpressions = false)
+        public TRuleTypeShouldConjunction HaveName(string pattern, bool useRegularExpressions = false)
         {
             _ruleCreator.ContinueComplexCondition(
-                ObjectPredicatesDefinition<TReferenceType>.HaveNameMatching(pattern, useRegularExpressions));
+                ObjectPredicatesDefinition<TReferenceType>.HaveName(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction HaveFullName(string fullname)
-        {
-            _ruleCreator.ContinueComplexCondition(ObjectPredicatesDefinition<TReferenceType>.HaveFullName(fullname));
-            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TRuleTypeShouldConjunction HaveFullNameMatching(string pattern, bool useRegularExpressions = false)
+        public TRuleTypeShouldConjunction HaveFullName(string pattern, bool useRegularExpressions = false)
         {
             _ruleCreator.ContinueComplexCondition(
-                ObjectPredicatesDefinition<TReferenceType>.HaveFullNameMatching(pattern, useRegularExpressions));
+                ObjectPredicatesDefinition<TReferenceType>.HaveFullName(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
@@ -805,30 +793,17 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction DoNotHaveName(string name)
+        public TRuleTypeShouldConjunction DoNotHaveName(string pattern, bool useRegularExpressions = false)
         {
-            _ruleCreator.ContinueComplexCondition(ObjectPredicatesDefinition<TReferenceType>.DoNotHaveName(name));
+            _ruleCreator.ContinueComplexCondition(
+                ObjectPredicatesDefinition<TReferenceType>.DoNotHaveName(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
-        public TRuleTypeShouldConjunction DoNotHaveNameMatching(string pattern, bool useRegularExpressions = false)
+        public TRuleTypeShouldConjunction DoNotHaveFullName(string pattern, bool useRegularExpressions = false)
         {
             _ruleCreator.ContinueComplexCondition(
-                ObjectPredicatesDefinition<TReferenceType>.DoNotHaveNameMatching(pattern, useRegularExpressions));
-            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TRuleTypeShouldConjunction DoNotHaveFullName(string fullname)
-        {
-            _ruleCreator.ContinueComplexCondition(
-                ObjectPredicatesDefinition<TReferenceType>.DoNotHaveFullName(fullname));
-            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
-        }
-
-        public TRuleTypeShouldConjunction DoNotHaveFullNameMatching(string pattern, bool useRegularExpressions = false)
-        {
-            _ruleCreator.ContinueComplexCondition(
-                ObjectPredicatesDefinition<TReferenceType>.DoNotHaveFullNameMatching(pattern, useRegularExpressions));
+                ObjectPredicatesDefinition<TReferenceType>.DoNotHaveFullName(pattern, useRegularExpressions));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/TypeConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/TypeConditionsDefinition.cs
@@ -64,9 +64,9 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         public static ICondition<TRuleType> BeAssignableTo(string pattern, bool useRegularExpressions = false)
         {
             var description = "be assignable to types with full name " +
-                              (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"";
+                              (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"";
             var failDescription = "is not assignable to a type with full name " +
-                                  (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"";
+                                  (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"";
             return new SimpleCondition<TRuleType>(type => type.IsAssignableTo(pattern, useRegularExpressions),
                 description, failDescription);
         }
@@ -92,12 +92,12 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
-                    "be assignable to types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "be assignable to types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
                 failDescription = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
-                    "is not assignable to types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"",
+                    "is not assignable to types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"",
                     (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
@@ -259,10 +259,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         {
             return new SimpleCondition<TRuleType>(
                 type => type.ImplementsInterface(pattern, useRegularExpressions),
-                "implement interface with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "implement interface with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"",
-                "does not implement interface with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "does not implement interface with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> ImplementInterface(Interface intf)
@@ -301,7 +301,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             return new SimpleCondition<TRuleType>(
                 type => type.ResidesInNamespace(pattern, useRegularExpressions),
                 obj => "does reside in " + obj.Namespace.FullName,
-                "reside in namespace with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "reside in namespace with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -310,7 +310,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             return new SimpleCondition<TRuleType>(
                 type => type.ResidesInAssembly(pattern, useRegularExpressions),
                 obj => "does reside in " + obj.Assembly.FullName,
-                "reside in assembly with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "reside in assembly with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -492,7 +492,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             }
 
             var description = "not be assignable to types with full name " +
-                              (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"";
+                              (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"";
             return new SimpleCondition<TRuleType>(Condition, description);
         }
 
@@ -526,8 +526,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
-                    "not be assignable to types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    "not be assignable to types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimpleCondition<TRuleType>(Condition, description);
@@ -703,10 +703,10 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         public static ICondition<TRuleType> NotImplementInterface(string pattern, bool useRegularExpressions = false)
         {
             return new SimpleCondition<TRuleType>(type => !type.ImplementsInterface(pattern, useRegularExpressions),
-                "not implement interface with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"",
-                "does implement interface with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "not implement interface with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"",
+                "does implement interface with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> NotImplementInterface(Interface intf)
@@ -745,8 +745,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             return new SimpleCondition<TRuleType>(
                 type => !type.ResidesInNamespace(pattern, useRegularExpressions),
                 obj => "does reside in " + obj.Namespace.FullName,
-                "not reside in namespace with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "not reside in namespace with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static ICondition<TRuleType> NotResideInAssembly(string pattern, bool useRegularExpressions = false)
@@ -754,7 +754,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             return new SimpleCondition<TRuleType>(
                 type => !type.ResidesInAssembly(pattern, useRegularExpressions),
                 obj => "does reside in " + obj.Assembly.FullName,
-                "not reside in assembly with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "not reside in assembly with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/TypePredicatesDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/TypePredicatesDefinition.cs
@@ -59,7 +59,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         public static IPredicate<T> AreAssignableTo(string pattern, bool useRegularExpressions = false)
         {
             var description = "are assignable to types with full name " +
-                              (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"";
+                              (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"";
             return new SimplePredicate<T>(type => type.IsAssignableTo(pattern, useRegularExpressions), description);
         }
 
@@ -81,8 +81,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             {
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
-                    "are assignable to types with full name " + (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    "are assignable to types with full name " + (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimplePredicate<T>(Condition, description);
@@ -195,7 +195,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         public static IPredicate<T> ImplementInterface(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(type => type.ImplementsInterface(pattern, useRegularExpressions),
-                "implement interface with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "implement interface with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -220,14 +220,14 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         public static IPredicate<T> ResideInNamespace(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(type => type.ResidesInNamespace(pattern, useRegularExpressions),
-                "reside in namespace with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "reside in namespace with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
         public static IPredicate<T> ResideInAssembly(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(type => type.ResidesInAssembly(pattern, useRegularExpressions),
-                "reside in assembly with full name " + (useRegularExpressions ? "matching" : "containing") + " \"" +
+                "reside in assembly with full name " + (useRegularExpressions ? "matching " : "") + "\"" +
                 pattern + "\"");
         }
 
@@ -321,7 +321,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         public static IPredicate<T> AreNotAssignableTo(string pattern, bool useRegularExpressions = false)
         {
             var description = "are not assignable to types with full name " +
-                              (useRegularExpressions ? "matching" : "containing") + " \"" + pattern + "\"";
+                              (useRegularExpressions ? "matching " : "") + "\"" + pattern + "\"";
             return new SimplePredicate<T>(type => !type.IsAssignableTo(pattern, useRegularExpressions), description);
         }
 
@@ -344,8 +344,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
                 var firstPattern = patternList.First();
                 description = patternList.Where(type => !type.Equals(firstPattern)).Distinct().Aggregate(
                     "are not assignable to types with full name " +
-                    (useRegularExpressions ? "matching" : "containing") +
-                    " \"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
+                    (useRegularExpressions ? "matching " : "") +
+                    "\"" + firstPattern + "\"", (current, pattern) => current + " or \"" + pattern + "\"");
             }
 
             return new SimplePredicate<T>(Condition, description);
@@ -458,8 +458,8 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         public static IPredicate<T> DoNotImplementInterface(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(type => !type.ImplementsInterface(pattern, useRegularExpressions),
-                "do not implement interface with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "do not implement interface with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static IPredicate<T> DoNotImplementInterface(Interface intf)
@@ -483,15 +483,15 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         public static IPredicate<T> DoNotResideInNamespace(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(type => !type.ResidesInNamespace(pattern, useRegularExpressions),
-                "do not reside in namespace with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "do not reside in namespace with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static IPredicate<T> DoNotResideInAssembly(string pattern, bool useRegularExpressions = false)
         {
             return new SimplePredicate<T>(type => !type.ResidesInAssembly(pattern, useRegularExpressions),
-                "do not reside in assembly with full name " + (useRegularExpressions ? "matching" : "containing") +
-                " \"" + pattern + "\"");
+                "do not reside in assembly with full name " + (useRegularExpressions ? "matching " : "") +
+                "\"" + pattern + "\"");
         }
 
         public static IPredicate<T> DoNotResideInAssembly(Assembly assembly, params Assembly[] moreAssemblies)

--- a/ArchUnitNETTests/Dependencies/ExternalDependenciesTests.cs
+++ b/ArchUnitNETTests/Dependencies/ExternalDependenciesTests.cs
@@ -30,10 +30,10 @@ namespace ArchUnitNETTests.Dependencies
         public void PropertyDependencyTest()
         {
             var notDependOnAnyRuleClass = Classes().That()
-                .HaveFullNameMatching(typeof(PropertyDependency).FullName).Should()
+                .HaveFullName(typeof(PropertyDependency).FullName).Should()
                 .NotDependOnAny(typeof(Class2));
             var notDependOnAnyRuleString = Classes().That()
-                .HaveFullNameMatching(typeof(PropertyDependency).FullName).Should()
+                .HaveFullName(typeof(PropertyDependency).FullName).Should()
                 .NotDependOnAny(typeof(Class2).FullName);
             Assert.False(notDependOnAnyRuleClass.HasNoViolations(Architecture)); //Class2 does not exist in Architecture
             Assert.False(notDependOnAnyRuleString.HasNoViolations(Architecture));
@@ -44,10 +44,10 @@ namespace ArchUnitNETTests.Dependencies
         public void MethodBodyDependencyTest()
         {
             var notDependOnAnyRuleClass = Classes().That()
-                .HaveFullNameMatching(typeof(MethodBodyDependency).FullName).Should()
+                .HaveFullName(typeof(MethodBodyDependency).FullName).Should()
                 .NotDependOnAny(typeof(Class3));
             var notDependOnAnyRuleString = Classes().That()
-                .HaveFullNameMatching(typeof(MethodBodyDependency).FullName).Should()
+                .HaveFullName(typeof(MethodBodyDependency).FullName).Should()
                 .NotDependOnAny(typeof(Class3).FullName);
             Assert.False(notDependOnAnyRuleClass.HasNoViolations(Architecture)); //Class3 does not exist in Architecture
             Assert.False(notDependOnAnyRuleString.HasNoViolations(Architecture));
@@ -58,10 +58,10 @@ namespace ArchUnitNETTests.Dependencies
         public void MethodArgumentDependencyTest()
         {
             var notDependOnAnyRuleClass = Classes().That()
-                .HaveFullNameMatching(typeof(MethodArgumentDependency).FullName).Should()
+                .HaveFullName(typeof(MethodArgumentDependency).FullName).Should()
                 .NotDependOnAny(typeof(Class2));
             var notDependOnAnyRuleString = Classes().That()
-                .HaveFullNameMatching(typeof(MethodArgumentDependency).FullName).Should()
+                .HaveFullName(typeof(MethodArgumentDependency).FullName).Should()
                 .NotDependOnAny(typeof(Class2).FullName);
             Assert.False(notDependOnAnyRuleClass.HasNoViolations(Architecture)); //Class3 does not exist in Architecture
             Assert.False(notDependOnAnyRuleString.HasNoViolations(Architecture));
@@ -71,10 +71,10 @@ namespace ArchUnitNETTests.Dependencies
         public void FieldDependencyTest()
         {
             var notDependOnAnyRuleClass = Classes().That()
-                .HaveFullNameMatching(typeof(FieldDependency).FullName).Should()
+                .HaveFullName(typeof(FieldDependency).FullName).Should()
                 .NotDependOnAny(typeof(Class2));
             var notDependOnAnyRuleString = Classes().That()
-                .HaveFullNameMatching(typeof(FieldDependency).FullName).Should()
+                .HaveFullName(typeof(FieldDependency).FullName).Should()
                 .NotDependOnAny(typeof(Class2).FullName);
             Assert.False(notDependOnAnyRuleClass.HasNoViolations(Architecture)); //Class3 does not exist in Architecture
             Assert.False(notDependOnAnyRuleString.HasNoViolations(Architecture));

--- a/ArchUnitNETTests/Domain/Extensions/TypeExtensionTests.cs
+++ b/ArchUnitNETTests/Domain/Extensions/TypeExtensionTests.cs
@@ -43,6 +43,7 @@ namespace ArchUnitNETTests.Domain.Extensions
 
         private readonly Class _exampleAttribute;
         private const string ExpectedAttributeNamespace = "ArchUnitNETTests.Domain.Dependencies.Attributes";
+        private const string ParentAttributeNamespace = "ArchUnitNETTests.Domain.Dependencies";
 
         private readonly Class _regexUtilsTests;
         private const string ExpectedRegexUtilsTestNamespace = "ArchUnitNETTests.Loader";
@@ -62,6 +63,18 @@ namespace ArchUnitNETTests.Domain.Extensions
             Assert.False(_methodOriginClass.FullNameContains("ClassMethod"));
             Assert.True(_methodMember.FullNameContains(""));
             Assert.False(_exampleAttribute.FullNameContains(null));
+        }
+
+        [Fact]
+        public void FullNameMatchesTest()
+        {
+            Assert.True(_fieldMember.FullNameMatches("(?i)ieLda", true));
+            Assert.True(_propertyOriginClass.FullNameMatches("(?i)sswITH", true));
+            Assert.False(_methodOriginClass.FullNameMatches("ClassMethod"));
+            Assert.False(_methodMember.FullNameMatches(""));
+            Assert.True(_methodMember.FullNameMatches(_methodMember.FullName));
+            Assert.True(_methodMember.FullNameMatches(_methodMember.FullName.ToLower()));
+            Assert.False(_exampleAttribute.FullNameMatches(null));
         }
 
         [Fact]
@@ -139,7 +152,9 @@ namespace ArchUnitNETTests.Domain.Extensions
             Assert.True(_fieldMember.NameMatches("(?i)ieLda", true));
             Assert.True(_propertyOriginClass.NameMatches("(?i)sswITH", true));
             Assert.False(_methodOriginClass.NameMatches("ClassMethod"));
-            Assert.True(_methodMember.NameMatches(""));
+            Assert.False(_methodMember.NameMatches(""));
+            Assert.True(_methodMember.NameMatches(_methodMember.Name));
+            Assert.True(_methodMember.NameMatches(_methodMember.Name.ToLower()));
             Assert.False(_exampleAttribute.NameMatches(null));
         }
 
@@ -147,8 +162,10 @@ namespace ArchUnitNETTests.Domain.Extensions
         public void NamespaceMatchAsExpected()
         {
             Assert.True(_exampleAttribute.ResidesInNamespace(ExpectedAttributeNamespace));
+            Assert.False(_exampleAttribute.ResidesInNamespace(ParentAttributeNamespace));
+            Assert.True(_exampleAttribute.ResidesInNamespace(ParentAttributeNamespace, true));
             Assert.True(_regexUtilsTests.ResidesInNamespace(ExpectedRegexUtilsTestNamespace));
-            Assert.True(_exampleAttribute.ResidesInNamespace(string.Empty));
+            Assert.False(_exampleAttribute.ResidesInNamespace(string.Empty));
         }
 
         [Fact]

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/MatchGenericReturnTypesTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/MatchGenericReturnTypesTests.cs
@@ -22,60 +22,59 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
         public void OneGenericParameter()
         {
             MethodMembers().That().AreDeclaredIn(typeof(OneGenericReturnTypeExample)).And()
-                .HaveNameMatching("CorrectGenericArgument").Should().HaveReturnType(typeof(ExampleGenericClass<>))
-                .Check(Architecture);
+                .HaveName("CorrectGenericArgument()").Should().Exist().AndShould()
+                .HaveReturnType(typeof(ExampleGenericClass<>)).Check(Architecture);
             MethodMembers().That().AreDeclaredIn(typeof(OneGenericReturnTypeExample)).And()
-                .HaveNameMatching("WrongGenericArgument").Should().HaveReturnType(typeof(ExampleGenericClass<>))
-                .Check(Architecture);
+                .HaveName("WrongGenericArgument()").Should().Exist().AndShould()
+                .HaveReturnType(typeof(ExampleGenericClass<>)).Check(Architecture);
             MethodMembers().That().AreDeclaredIn(typeof(OneGenericReturnTypeExample)).And()
-                .HaveNameMatching("WrongReturnType")
-                .Should().NotHaveReturnType(typeof(ExampleGenericClass<>)).Check(Architecture);
+                .HaveNameContaining("WrongReturnType")
+                .Should().Exist().AndShould().NotHaveReturnType(typeof(ExampleGenericClass<>)).Check(Architecture);
         }
 
         [Fact]
         public void TwoGenericParameters()
         {
             MethodMembers().That().AreDeclaredIn(typeof(TwoGenericReturnTypesExample)).And()
-                .HaveNameMatching("CorrectGenericArgument").Should().HaveReturnType(typeof(ExampleGenericClass<,>))
-                .Check(Architecture);
+                .HaveName("CorrectGenericArgument()").Should().Exist().AndShould()
+                .HaveReturnType(typeof(ExampleGenericClass<,>)).Check(Architecture);
             MethodMembers().That().AreDeclaredIn(typeof(TwoGenericReturnTypesExample)).And()
-                .HaveNameMatching("WrongGenericArgument").Should().HaveReturnType(typeof(ExampleGenericClass<,>))
-                .Check(Architecture);
+                .HaveName("WrongGenericArgument()").Should().Exist().AndShould()
+                .HaveReturnType(typeof(ExampleGenericClass<,>)).Check(Architecture);
             MethodMembers().That().AreDeclaredIn(typeof(TwoGenericReturnTypesExample)).And()
-                .HaveNameMatching("WrongReturnType")
-                .Should().NotHaveReturnType(typeof(ExampleGenericClass<,>)).Check(Architecture);
+                .HaveNameContaining("WrongReturnType")
+                .Should().Exist().AndShould().NotHaveReturnType(typeof(ExampleGenericClass<,>)).Check(Architecture);
         }
 
         [Fact]
         public void OneGenericArgument()
         {
             MethodMembers().That().AreDeclaredIn(typeof(OneGenericReturnTypeExample)).And()
-                .HaveNameMatching("CorrectGenericArgument").Should()
-                .HaveReturnType(typeof(ExampleGenericClass<ExampleArgument>))
-                .Check(Architecture);
+                .HaveName("CorrectGenericArgument()").Should().Exist().AndShould()
+                .HaveReturnType(typeof(ExampleGenericClass<ExampleArgument>)).Check(Architecture);
             MethodMembers().That().AreDeclaredIn(typeof(OneGenericReturnTypeExample)).And()
-                .HaveNameMatching("WrongGenericArgument").Should()
-                .NotHaveReturnType(typeof(ExampleGenericClass<ExampleArgument>))
-                .Check(Architecture);
+                .HaveName("WrongGenericArgument()").Should().Exist().AndShould()
+                .NotHaveReturnType(typeof(ExampleGenericClass<ExampleArgument>)).Check(Architecture);
             MethodMembers().That().AreDeclaredIn(typeof(OneGenericReturnTypeExample)).And()
-                .HaveNameMatching("WrongReturnType")
-                .Should().NotHaveReturnType(typeof(ExampleGenericClass<ExampleArgument>)).Check(Architecture);
+                .HaveNameContaining("WrongReturnType").Should().Exist().AndShould()
+                .NotHaveReturnType(typeof(ExampleGenericClass<ExampleArgument>)).Check(Architecture);
         }
 
         [Fact]
         public void TwoGenericArguments()
         {
             MethodMembers().That().AreDeclaredIn(typeof(TwoGenericReturnTypesExample)).And()
-                .HaveNameMatching("CorrectGenericArgument").Should()
-                .HaveReturnType(typeof(ExampleGenericClass<ExampleArgument, int>))
+                .HaveName("CorrectGenericArgument()").Should()
+                .Exist().AndShould().HaveReturnType(typeof(ExampleGenericClass<ExampleArgument, int>))
                 .Check(Architecture);
             MethodMembers().That().AreDeclaredIn(typeof(TwoGenericReturnTypesExample)).And()
-                .HaveNameMatching("WrongGenericArgument").Should()
-                .NotHaveReturnType(typeof(ExampleGenericClass<ExampleArgument, int>))
+                .HaveName("WrongGenericArgument()").Should()
+                .Exist().AndShould().NotHaveReturnType(typeof(ExampleGenericClass<ExampleArgument, int>))
                 .Check(Architecture);
             MethodMembers().That().AreDeclaredIn(typeof(TwoGenericReturnTypesExample)).And()
-                .HaveNameMatching("WrongReturnType")
-                .Should().NotHaveReturnType(typeof(ExampleGenericClass<ExampleArgument, int>)).Check(Architecture);
+                .HaveNameContaining("WrongReturnType")
+                .Should().Exist().AndShould().NotHaveReturnType(typeof(ExampleGenericClass<ExampleArgument, int>))
+                .Check(Architecture);
         }
     }
 

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/MemberSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/MemberSyntaxElementsTests.cs
@@ -36,8 +36,8 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
         private readonly List<string> _falseTypeConstructors =
             new List<string> {PublicTestClassConstructor, InternalTestClassConstructor};
 
-        private const string PublicTestClassConstructor = "ArchUnitNETTests.Domain.PublicTestClass::.ctor()";
-        private const string InternalTestClassConstructor = "ArchUnitNETTests.Domain.InternalTestClass::.ctor()";
+        private const string PublicTestClassConstructor = "System.Void ArchUnitNETTests.Domain.PublicTestClass::.ctor()";
+        private const string InternalTestClassConstructor = "System.Void ArchUnitNETTests.Domain.InternalTestClass::.ctor()";
 
         [Fact]
         public void DeclaredInTest()

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/MethodMemberSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/MethodMemberSyntaxElementsTests.cs
@@ -101,7 +101,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             foreach (var methodMember in _methodMembers)
             {
                 foreach (var callingType in methodMember.GetMethodCallDependencies(true)
-                    .Select(dependency => dependency.Origin.FullName))
+                             .Select(dependency => dependency.Origin.FullName))
                 {
                     var methodIsCalledByRightType =
                         MethodMembers().That().Are(methodMember).Should().BeCalledBy(callingType);
@@ -148,7 +148,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             foreach (var methodMember in _methodMembers)
             {
                 foreach (var dependency in methodMember.GetBodyTypeMemberDependencies()
-                    .Select(dependency => dependency.Target.FullName))
+                             .Select(dependency => dependency.Target.FullName))
                 {
                     var hasRightDependency = MethodMembers().That().Are(methodMember).Should()
                         .HaveDependencyInMethodBodyTo(dependency);
@@ -177,11 +177,11 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
         [Fact]
         public void HaveReturnTypeConditionTest()
         {
-            var stringReturnTypes = new List<string> {"void", "string", "ReturnTypeClass"};
+            var stringReturnTypes = new List<string> {"Void", "String", "ReturnTypeClass"};
             var retTypeWithString = MethodMembers().That().HaveFullNameContaining("ReturnTypeMethod").Should()
-                .HaveReturnType(stringReturnTypes);
+                .HaveReturnType(stringReturnTypes, true);
             var retTypeWithStringFail = MethodMembers().That().HaveFullNameContaining("ReturnTypeMethod").Should()
-                .HaveReturnType("bool");
+                .HaveReturnType("bool", true);
 
             Assert.True(retTypeWithString.HasNoViolations(Architecture));
             Assert.False(retTypeWithStringFail.HasNoViolations(Architecture));
@@ -217,11 +217,11 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
         [Fact]
         public void NotHaveReturnTypeConditionTest()
         {
-            var stringReturnTypes = new List<string> {"void", "string", "ReturnTypeClass"};
+            var stringReturnTypes = new List<string> {"Void", "String", "ReturnTypeClass"};
             var retTypeWithString = MethodMembers().That().HaveFullNameContaining("ReturnTypeMethod").Should()
-                .NotHaveReturnType("bool");
+                .NotHaveReturnType("bool", true);
             var retTypeWithStringFail = MethodMembers().That().HaveFullNameContaining("ReturnTypeMethod").Should()
-                .NotHaveReturnType(stringReturnTypes);
+                .NotHaveReturnType(stringReturnTypes, true);
 
             Assert.True(retTypeWithString.HasNoViolations(Architecture));
             Assert.False(retTypeWithStringFail.HasNoViolations(Architecture));
@@ -259,9 +259,9 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
         {
             var stringReturnTypes = new List<string> {"void", "string"};
             var retTypeWithString = MethodMembers().That().HaveFullNameContaining("ReturnTypeMethod").And()
-                .HaveReturnType(stringReturnTypes).Should().HaveFullNameContaining("Void").OrShould()
+                .HaveReturnType(stringReturnTypes, true).Should().HaveFullNameContaining("Void").OrShould()
                 .HaveFullNameContaining("String");
-            var retTypeWithStringNegate = MethodMembers().That().DoNotHaveReturnType("String").And()
+            var retTypeWithStringNegate = MethodMembers().That().DoNotHaveReturnType("String", true).And()
                 .HaveFullNameContaining("ReturnTypeMethod").Should().NotHaveFullNameContaining("String");
 
             Assert.True(retTypeWithString.HasNoViolations(Architecture));
@@ -276,9 +276,9 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             Assert.False(retTypeWithTypeFail.HasNoViolations(Architecture));
 
             var objectProviderClass = Classes().That().HaveFullNameContaining("ReturnTypeClass");
-            var retTypeWithObjectProvider = MethodMembers().That().HaveReturnType("ReturnTypeClass")
+            var retTypeWithObjectProvider = MethodMembers().That().HaveReturnType("ReturnTypeClass",true)
                 .Should().HaveFullNameContaining("ReturnTypeMethodClass");
-            var retTypeWithObjectProviderFail = MethodMembers().That().DoNotHaveReturnType("ReturnTypeClass")
+            var retTypeWithObjectProviderFail = MethodMembers().That().DoNotHaveReturnType("ReturnTypeClass",true)
                 .And().HaveFullNameContaining("ReturnTypeMethod")
                 .Should().HaveFullNameContaining("ReturnTypeMethodClass");
 


### PR DESCRIPTION
If regex use is not explicitly specified, patterns now only match the name and full name of types, if they are exactly equal. Previously it also matched if the name contained the pattern. One problem with this was for example that the name of a parent namespaces matched to all child namespaces.