### PR TITLE
Only list forbidden dependencies in error messages

### DIFF
--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
@@ -1,7 +1,7 @@
 ﻿//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
 // 	Copyright 2019 Paula Ruiz <paularuiz22@gmail.com>
 // 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
-// 
+//
 // 	SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -2015,7 +2015,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                 {
                     var dynamicFailDescription = "does depend on";
                     var first = true;
-                    foreach (var type in failedObject.GetTypeDependencies().Union(typeList))
+                    foreach (var type in failedObject.GetTypeDependencies().Intersect(typeList))
                     {
                         dynamicFailDescription += first ? " " + type.FullName : " and " + type.FullName;
                         first = false;
@@ -2047,7 +2047,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                 {
                     var dynamicFailDescription = "does depend on";
                     var first = true;
-                    foreach (var type in failedObject.GetTypeDependencies().Union(typeList))
+                    foreach (var type in failedObject.GetTypeDependencies().Intersect(typeList))
                     {
                         dynamicFailDescription += first ? " " + type.FullName : " and " + type.FullName;
                         first = false;
@@ -2092,7 +2092,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                 {
                     var dynamicFailDescription = "does depend on";
                     var first = true;
-                    foreach (var type in failedObject.GetTypeDependencies().Union(iTypeList))
+                    foreach (var type in failedObject.GetTypeDependencies().Intersect(iTypeList))
                     {
                         dynamicFailDescription += first ? " " + type.FullName : " and " + type.FullName;
                         first = false;

--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
@@ -1865,7 +1865,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                 {
                     var dynamicFailDescription = "does call";
                     var first = true;
-                    foreach (var method in failedObject.GetCalledMethods().Union(methodList))
+                    foreach (var method in failedObject.GetCalledMethods().Intersect(methodList))
                     {
                         dynamicFailDescription += first ? " " + method.FullName : " and " + method.FullName;
                         first = false;
@@ -1897,7 +1897,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                 {
                     var dynamicFailDescription = "does call";
                     var first = true;
-                    foreach (var method in failedObject.GetCalledMethods().Union(methodList))
+                    foreach (var method in failedObject.GetCalledMethods().Intersect(methodList))
                     {
                         dynamicFailDescription += first ? " " + method.FullName : " and " + method.FullName;
                         first = false;

--- a/ArchUnitNETTests/Fluent/ObjectConditionsErrorMessagesTests.cs
+++ b/ArchUnitNETTests/Fluent/ObjectConditionsErrorMessagesTests.cs
@@ -1,0 +1,63 @@
+//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+//
+// 	SPDX-License-Identifier: Apache-2.0
+//
+
+using System.Linq;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using TestAssembly;
+using Xunit;
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+namespace ArchUnitNETTests.Fluent
+{
+    public class ObjectConditionsErrorMessagesTests
+    {
+        private static readonly Architecture Architecture = StaticTestArchitectures.ArchUnitNETTestAssemblyArchitecture;
+
+        private void AssertFailsWithErrorMessage(IArchRule rule, string errorMessage)
+        {
+            var evaluationResults = rule.Evaluate(Architecture);
+            var failedResults = evaluationResults.Where(r => !r.Passed);
+            Assert.Equal(errorMessage, failedResults.Single().Description);
+        }
+
+        [Fact]
+        public void OnlyListForbiddenITypesInError()
+        {
+            var rule = Classes().That().Are(typeof(Class1)).Should().NotDependOnAnyTypesThat().Are(typeof(Class2));
+            AssertFailsWithErrorMessage(rule, "TestAssembly.Class1 does depend on TestAssembly.Class2");
+        }
+
+        [Fact]
+        public void OnlyListForbiddenTypesInError()
+        {
+            var rule = Classes().That().Are(typeof(Class1)).Should().NotDependOnAny(typeof(Class2));
+            AssertFailsWithErrorMessage(rule, "TestAssembly.Class1 does depend on TestAssembly.Class2");
+        }
+
+        [Fact]
+        public void OnlyListForbiddenMethodsInErrors()
+        {
+            var rule = MethodMembers().That().AreDeclaredIn(typeof(ClassCallingOtherMethod)).Should()
+                .NotCallAny(MethodMembers().That().AreDeclaredIn(typeof(Class1)));
+            AssertFailsWithErrorMessage(rule,
+                "System.Void TestAssembly.ClassCallingOtherMethod::CallingOther(TestAssembly.Class1)" +
+                " does call System.String TestAssembly.Class1::AccessClass2(System.Int32)");
+        }
+
+        [Fact]
+        public void OnlyListForbiddenMethodsFromEnumerableInErrors()
+        {
+            var methodsInClass1 = MethodMembers().That().AreDeclaredIn(typeof(Class1)).GetObjects(Architecture);
+            var rule = MethodMembers().That().AreDeclaredIn(typeof(ClassCallingOtherMethod)).Should()
+                .NotCallAny(methodsInClass1);
+            AssertFailsWithErrorMessage(rule,
+                "System.Void TestAssembly.ClassCallingOtherMethod::CallingOther(TestAssembly.Class1)" +
+                " does call System.String TestAssembly.Class1::AccessClass2(System.Int32)");
+        }
+    }
+}

--- a/TestAssembly/ClassCallingOtherMethod.cs
+++ b/TestAssembly/ClassCallingOtherMethod.cs
@@ -1,0 +1,20 @@
+//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+//
+// 	SPDX-License-Identifier: Apache-2.0
+//
+
+using System;
+
+namespace TestAssembly
+{
+    public class ClassCallingOtherMethod
+    {
+        public void CallingOther(Class1 cls)
+        {
+            Console.Write(cls.ToString());
+            cls.AccessClass2(1);
+        }
+    }
+}


### PR DESCRIPTION
There was a bug in the error reports when types depend on forbidden types or methods are calling forbidden methods. Due to a Union being used instead of an Intersect, all dependencies were reported in the error instead of only the ones that are forbidden. This should fix #143 