### PR TITLE
Rewrite IsAssignableTo() and ImplementsInterface() methods as TypeExtensions

### DIFF
--- a/ArchUnitNET/Domain/Class.cs
+++ b/ArchUnitNET/Domain/Class.cs
@@ -67,27 +67,6 @@ namespace ArchUnitNET.Domain
 
         public List<GenericParameter> GenericParameters => Type.GenericParameters;
 
-        public bool ImplementsInterface(Interface intf)
-        {
-            return Type.ImplementsInterface(intf);
-        }
-
-        public bool ImplementsInterface(string pattern, bool useRegularExpressions = false)
-        {
-            return Type.ImplementsInterface(pattern, useRegularExpressions);
-        }
-
-        public bool IsAssignableTo(IType assignableToType)
-        {
-            return this.GetAssignableTypes().Contains(assignableToType);
-        }
-
-        public bool IsAssignableTo(string pattern, bool useRegularExpressions = false)
-        {
-            return pattern != null && this.GetAssignableTypes()
-                .Any(type => type.FullNameMatches(pattern, useRegularExpressions));
-        }
-
         public override string ToString()
         {
             return FullName;

--- a/ArchUnitNET/Domain/Enum.cs
+++ b/ArchUnitNET/Domain/Enum.cs
@@ -51,27 +51,6 @@ namespace ArchUnitNET.Domain
         public MemberList Members => Type.Members;
         public List<GenericParameter> GenericParameters => Type.GenericParameters;
 
-        public bool ImplementsInterface(Interface intf)
-        {
-            return Type.ImplementsInterface(intf);
-        }
-
-        public bool ImplementsInterface(string pattern, bool useRegularExpressions = false)
-        {
-            return Type.ImplementsInterface(pattern, useRegularExpressions);
-        }
-
-        public bool IsAssignableTo(IType assignableToType)
-        {
-            return this.GetAssignableTypes().Contains(assignableToType);
-        }
-
-        public bool IsAssignableTo(string pattern, bool useRegularExpressions = false)
-        {
-            return pattern != null && this.GetAssignableTypes()
-                .Any(type => type.FullNameMatches(pattern, useRegularExpressions));
-        }
-
         public override string ToString()
         {
             return FullName;

--- a/ArchUnitNET/Domain/Extensions/TypeExtensions.cs
+++ b/ArchUnitNET/Domain/Extensions/TypeExtensions.cs
@@ -14,6 +14,48 @@ namespace ArchUnitNET.Domain.Extensions
 {
     public static class TypeExtensions
     {
+        public static bool ImplementsInterface(this IType type, Interface intf)
+        {
+            if (type is GenericParameter)
+            {
+                return false;
+            }
+
+            return type.ImplementedInterfaces.Any(implementedInterface =>
+                Equals(implementedInterface, intf));
+        }
+
+        public static bool ImplementsInterface(this IType type, string pattern, bool useRegularExpressions = false)
+        {
+            if (type is GenericParameter)
+            {
+                return false;
+            }
+
+            return type.ImplementedInterfaces.Any(implementedInterface =>
+                implementedInterface.FullNameMatches(pattern, useRegularExpressions));
+        }
+
+        public static bool IsAssignableTo(this IType type, IType assignableToType)
+        {
+            if (type is GenericParameter genericParameter)
+            {
+                return genericParameter.TypeConstraints.All(t => t.IsAssignableTo(assignableToType));
+            }
+
+            return type.GetAssignableTypes().Contains(assignableToType);
+        }
+
+        public static bool IsAssignableTo(this IType type, string pattern, bool useRegularExpressions = false)
+        {
+            if (type is GenericParameter genericParameter)
+            {
+                return genericParameter.TypeConstraints.All(t => t.IsAssignableTo(pattern, useRegularExpressions));
+            }
+
+            return type.GetAssignableTypes().Any(t => t.FullNameMatches(pattern, useRegularExpressions));
+        }
+
         public static bool IsAnonymousType(this IType type)
         {
             return type.NameStartsWith("<>f__AnonymousType");

--- a/ArchUnitNET/Domain/GenericParameter.cs
+++ b/ArchUnitNET/Domain/GenericParameter.cs
@@ -65,26 +65,6 @@ namespace ArchUnitNET.Domain
         public bool IsNested => true;
         public bool IsStub => true;
 
-        public bool ImplementsInterface(Interface intf)
-        {
-            return false;
-        }
-
-        public bool ImplementsInterface(string pattern, bool useRegularExpressions = false)
-        {
-            return false;
-        }
-
-        public bool IsAssignableTo(IType assignableToType)
-        {
-            return TypeConstraints.All(type => type.IsAssignableTo(assignableToType));
-        }
-
-        public bool IsAssignableTo(string pattern, bool useRegularExpressions = false)
-        {
-            return pattern != null && TypeConstraints.All(type => type.IsAssignableTo(pattern, useRegularExpressions));
-        }
-
         internal void AssignDeclarer(IMember declaringMethod)
         {
             if (!declaringMethod.FullName.Equals(_declarerFullName))

--- a/ArchUnitNET/Domain/IType.cs
+++ b/ArchUnitNET/Domain/IType.cs
@@ -17,9 +17,5 @@ namespace ArchUnitNET.Domain
         bool IsNested { get; }
         bool IsStub { get; }
         bool IsGenericParameter { get; }
-        bool ImplementsInterface(Interface intf);
-        bool ImplementsInterface(string pattern, bool useRegularExpressions = false);
-        bool IsAssignableTo(IType assignableToType);
-        bool IsAssignableTo(string pattern, bool useRegularExpressions = false);
     }
 }

--- a/ArchUnitNET/Domain/Interface.cs
+++ b/ArchUnitNET/Domain/Interface.cs
@@ -42,32 +42,6 @@ namespace ArchUnitNET.Domain
         public MemberList Members => Type.Members;
         public List<GenericParameter> GenericParameters => Type.GenericParameters;
 
-        public bool ImplementsInterface(Interface intf)
-        {
-            return Type.ImplementsInterface(intf);
-        }
-
-        public bool ImplementsInterface(string pattern, bool useRegularExpressions = false)
-        {
-            return Type.ImplementsInterface(pattern, useRegularExpressions);
-        }
-
-        public bool IsAssignableTo(IType assignableToType)
-        {
-            if (assignableToType is Interface intf)
-            {
-                return Equals(intf) || ImplementsInterface(intf);
-            }
-
-            return false;
-        }
-
-        public bool IsAssignableTo(string pattern, bool useRegularExpressions = false)
-        {
-            return this.FullNameMatches(pattern, useRegularExpressions) ||
-                   ImplementsInterface(pattern, useRegularExpressions);
-        }
-
         public override string ToString()
         {
             return FullName;

--- a/ArchUnitNET/Domain/Struct.cs
+++ b/ArchUnitNET/Domain/Struct.cs
@@ -51,27 +51,6 @@ namespace ArchUnitNET.Domain
         public MemberList Members => Type.Members;
         public List<GenericParameter> GenericParameters => Type.GenericParameters;
 
-        public bool ImplementsInterface(Interface intf)
-        {
-            return Type.ImplementsInterface(intf);
-        }
-
-        public bool ImplementsInterface(string pattern, bool useRegularExpressions = false)
-        {
-            return Type.ImplementsInterface(pattern, useRegularExpressions);
-        }
-
-        public bool IsAssignableTo(IType assignableToType)
-        {
-            return this.GetAssignableTypes().Contains(assignableToType);
-        }
-
-        public bool IsAssignableTo(string pattern, bool useRegularExpressions = false)
-        {
-            return pattern != null && this.GetAssignableTypes()
-                .Any(type => type.FullNameMatches(pattern, useRegularExpressions));
-        }
-
         public override string ToString()
         {
             return FullName;

--- a/ArchUnitNET/Loader/Type.cs
+++ b/ArchUnitNET/Loader/Type.cs
@@ -60,49 +60,6 @@ namespace ArchUnitNET.Loader
             .OfType<ImplementsInterfaceDependency>()
             .Select(dependency => dependency.Target);
 
-        public bool ImplementsInterface(Interface intf)
-        {
-            return ImplementedInterfaces.Any(implementedInterface =>
-                Equals(implementedInterface, intf));
-        }
-
-        public bool ImplementsInterface(string pattern, bool useRegularExpressions = false)
-        {
-            if (pattern == null)
-            {
-                return false;
-            }
-
-            return ImplementedInterfaces.Any(implementedInterface =>
-                implementedInterface.FullNameMatches(pattern, useRegularExpressions));
-        }
-
-        public bool IsAssignableTo(IType assignableToType)
-        {
-            if (assignableToType == null)
-            {
-                return false;
-            }
-
-            if (Equals(assignableToType))
-            {
-                return true;
-            }
-
-            return assignableToType is Interface && ImplementsInterface((Interface) assignableToType);
-        }
-
-        public bool IsAssignableTo(string pattern, bool useRegularExpressions = false)
-        {
-            if (pattern == null)
-            {
-                return false;
-            }
-
-            return this.FullNameMatches(pattern, useRegularExpressions) ||
-                   ImplementsInterface(pattern, useRegularExpressions);
-        }
-
         public override string ToString()
         {
             return FullName;

--- a/ArchUnitNETTests/Domain/InterfaceTests.cs
+++ b/ArchUnitNETTests/Domain/InterfaceTests.cs
@@ -5,6 +5,7 @@
 // 	SPDX-License-Identifier: Apache-2.0
 
 using ArchUnitNET.Domain;
+using ArchUnitNET.Domain.Extensions;
 using JetBrains.Annotations;
 using Xunit;
 using static ArchUnitNET.Domain.Visibility;

--- a/ArchUnitNETTests/Loader/TypeTests.cs
+++ b/ArchUnitNETTests/Loader/TypeTests.cs
@@ -18,9 +18,6 @@ namespace ArchUnitNETTests.Loader
     public class TypeTests
     {
         private readonly Architecture _architecture = StaticTestArchitectures.ArchUnitNETTestArchitecture;
-        private readonly object _duplicateReference;
-        private readonly Type _duplicateType;
-        private readonly Interface _exampleInterface;
         private readonly Class _expectedAttributeClass;
         private readonly Type _type;
 
@@ -28,14 +25,6 @@ namespace ArchUnitNETTests.Loader
         {
             _type = _architecture.GetClassOfType(typeof(AssignClass)).CreateShallowStubType();
             _type.RequiredNotNull();
-
-            _duplicateType = _architecture.GetClassOfType(typeof(AssignClass)).CreateShallowStubType();
-            _duplicateType.RequiredNotNull();
-
-            _duplicateReference = _type;
-
-            _exampleInterface = _architecture.GetInterfaceOfType(typeof(IExample));
-            _exampleInterface.RequiredNotNull();
             _expectedAttributeClass = _architecture.GetClassOfType(typeof(ExampleAttribute));
         }
 
@@ -112,36 +101,6 @@ namespace ArchUnitNETTests.Loader
 
             //Assert
             Assert.Contains(attribute, _type.Attributes);
-        }
-
-        [Fact]
-        public void IsAssignableToDuplicate()
-        {
-            Assert.True(_type.IsAssignableTo(_duplicateType));
-        }
-
-        [Fact]
-        public void IsAssignableToImplementedInterface()
-        {
-            //Setup, Act
-            var interfaceDependency =
-                new ImplementsInterfaceDependency(_type, new TypeInstance<Interface>(_exampleInterface));
-            _type.Dependencies.Add(interfaceDependency);
-
-            //Assert
-            Assert.True(_type.IsAssignableTo(_exampleInterface));
-        }
-
-        [Fact]
-        public void IsAssignableToItself()
-        {
-            Assert.True(_type.IsAssignableTo(_type));
-        }
-
-        [Fact]
-        public void IsAssignableToReferenceCopy()
-        {
-            Assert.True(_type.IsAssignableTo(_duplicateReference as IType));
         }
 
         [Fact]


### PR DESCRIPTION
The behaviour doesn't change except for Type, which should not be used for analysis