### PR TITLE
Allow Domain.Assembly as input parameter for ResideInAssembly()

### DIFF
--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/GivenTypesThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/GivenTypesThat.cs
@@ -138,6 +138,13 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
                 TypePredicatesDefinition<TRuleType>.ResideInAssembly(assembly, moreAssemblies));
             return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
         }
+        
+        public TGivenRuleTypeConjunction ResideInAssembly(Domain.Assembly assembly, params Domain.Assembly[] moreAssemblies)
+        {
+            _ruleCreator.AddPredicate(
+                TypePredicatesDefinition<TRuleType>.ResideInAssembly(assembly, moreAssemblies));
+            return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
+        }
 
         public TGivenRuleTypeConjunction HavePropertyMemberWithName(string name)
         {
@@ -284,6 +291,13 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         }
 
         public TGivenRuleTypeConjunction DoNotResideInAssembly(Assembly assembly, params Assembly[] moreAssemblies)
+        {
+            _ruleCreator.AddPredicate(
+                TypePredicatesDefinition<TRuleType>.DoNotResideInAssembly(assembly, moreAssemblies));
+            return Create<TGivenRuleTypeConjunction, TRuleType>(_ruleCreator);
+        }
+        
+        public TGivenRuleTypeConjunction DoNotResideInAssembly(Domain.Assembly assembly, params Domain.Assembly[] moreAssemblies)
         {
             _ruleCreator.AddPredicate(
                 TypePredicatesDefinition<TRuleType>.DoNotResideInAssembly(assembly, moreAssemblies));

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/ITypeConditions.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/ITypeConditions.cs
@@ -32,6 +32,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         TReturnType ResideInNamespace(string pattern, bool useRegularExpressions = false);
         TReturnType ResideInAssembly(string pattern, bool useRegularExpressions = false);
         TReturnType ResideInAssembly(Assembly assembly, params Assembly[] moreAssemblies);
+        TReturnType ResideInAssembly(Domain.Assembly assembly, params Domain.Assembly[] moreAssemblies);
         TReturnType HavePropertyMemberWithName(string name);
         TReturnType HaveFieldMemberWithName(string name);
         TReturnType HaveMethodMemberWithName(string name);
@@ -60,6 +61,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         TReturnType NotResideInNamespace(string pattern, bool useRegularExpressions = false);
         TReturnType NotResideInAssembly(string pattern, bool useRegularExpressions = false);
         TReturnType NotResideInAssembly(Assembly assembly, params Assembly[] moreAssemblies);
+        TReturnType NotResideInAssembly(Domain.Assembly assembly, params Domain.Assembly[] moreAssemblies);
         TReturnType NotHavePropertyMemberWithName(string name);
         TReturnType NotHaveFieldMemberWithName(string name);
         TReturnType NotHaveMethodMemberWithName(string name);

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/ITypePredicates.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/ITypePredicates.cs
@@ -32,6 +32,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         TReturnType ResideInNamespace(string pattern, bool useRegularExpressions = false);
         TReturnType ResideInAssembly(string pattern, bool useRegularExpressions = false);
         TReturnType ResideInAssembly(Assembly assembly, params Assembly[] moreAssemblies);
+        TReturnType ResideInAssembly(Domain.Assembly assembly, params Domain.Assembly[] moreAssemblies);
         TReturnType HavePropertyMemberWithName(string name);
         TReturnType HaveFieldMemberWithName(string name);
         TReturnType HaveMethodMemberWithName(string name);
@@ -60,6 +61,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         TReturnType DoNotResideInNamespace(string pattern, bool useRegularExpressions = false);
         TReturnType DoNotResideInAssembly(string pattern, bool useRegularExpressions = false);
         TReturnType DoNotResideInAssembly(Assembly assembly, params Assembly[] moreAssemblies);
+        TReturnType DoNotResideInAssembly(Domain.Assembly assembly, params Domain.Assembly[] moreAssemblies);
         TReturnType DoNotHavePropertyMemberWithName(string name);
         TReturnType DoNotHaveFieldMemberWithName(string name);
         TReturnType DoNotHaveMethodMemberWithName(string name);

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/ShouldRelateToTypesThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/ShouldRelateToTypesThat.cs
@@ -143,6 +143,14 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
 
+        public TRuleTypeShouldConjunction ResideInAssembly(Domain.Assembly assembly,
+            params Domain.Assembly[] moreAssemblies)
+        {
+            _ruleCreator.ContinueComplexCondition(
+                TypePredicatesDefinition<TReferenceType>.ResideInAssembly(assembly, moreAssemblies));
+            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
+        }
+
         public TRuleTypeShouldConjunction HavePropertyMemberWithName(string name)
         {
             _ruleCreator.ContinueComplexCondition(
@@ -294,6 +302,14 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         }
 
         public TRuleTypeShouldConjunction DoNotResideInAssembly(Assembly assembly, params Assembly[] moreAssemblies)
+        {
+            _ruleCreator.ContinueComplexCondition(
+                TypePredicatesDefinition<TReferenceType>.DoNotResideInAssembly(assembly, moreAssemblies));
+            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
+        }
+
+        public TRuleTypeShouldConjunction DoNotResideInAssembly(Domain.Assembly assembly,
+            params Domain.Assembly[] moreAssemblies)
         {
             _ruleCreator.ContinueComplexCondition(
                 TypePredicatesDefinition<TReferenceType>.DoNotResideInAssembly(assembly, moreAssemblies));

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/TypeConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/TypeConditionsDefinition.cs
@@ -380,6 +380,21 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
                 (type, architecture) => "does reside in " + type.Assembly.FullName, description);
         }
 
+        public static ICondition<TRuleType> ResideInAssembly(Assembly assembly, Assembly[] moreAssemblies)
+        {
+            bool Condition(TRuleType ruleType)
+            {
+                var assemblies = new[] {assembly}.Concat(moreAssemblies);
+                return assemblies.Contains(ruleType.Assembly);
+            }
+
+            var description = moreAssemblies.Aggregate("reside in assembly \"" + assembly.FullName + "\"",
+                (current, asm) => current + " or \"" + asm.FullName + "\"");
+
+            return new SimpleCondition<TRuleType>(Condition, type => "does reside in " + type.Assembly.FullName,
+                description);
+        }
+
         public static ICondition<TRuleType> HavePropertyMemberWithName(string name)
         {
             return new SimpleCondition<TRuleType>(type => type.HasPropertyMemberWithName(name),
@@ -870,6 +885,20 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
 
             return new ArchitectureCondition<TRuleType>(Condition,
                 (type, architecture) => "does reside in " + type.Assembly.FullName, description);
+        }
+        
+        public static ICondition<TRuleType> NotResideInAssembly(Assembly assembly, params Assembly[] moreAssemblies)
+        {
+            bool Condition(TRuleType ruleType)
+            {
+                var assemblies = new[] {assembly}.Concat(moreAssemblies);
+                return !assemblies.Contains(ruleType.Assembly);
+            }
+
+            var description = moreAssemblies.Aggregate("not reside in assembly \"" + assembly.FullName + "\"",
+                (current, asm) => current + " or \"" + asm.FullName + "\"");
+
+            return new SimpleCondition<TRuleType>(Condition, type => "does reside in " + type.Assembly.FullName, description);
         }
 
         public static ICondition<TRuleType> NotHavePropertyMemberWithName(string name)

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/TypePredicatesDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/TypePredicatesDefinition.cs
@@ -275,6 +275,20 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             return new ArchitecturePredicate<T>(Condition, description);
         }
 
+        public static IPredicate<T> ResideInAssembly(Domain.Assembly assembly, params Domain.Assembly[] moreAssemblies)
+        {
+            IEnumerable<T> Condition(IEnumerable<T> types)
+            {
+                var assemblyList = moreAssemblies.Concat(new[] {assembly});
+                return types.Where(type => assemblyList.Contains(type.Assembly));
+            }
+
+            var description = moreAssemblies.Aggregate("reside in assembly \"" + assembly.FullName + "\"",
+                (current, asm) => current + " or \"" + asm.FullName + "\"");
+
+            return new EnumerablePredicate<T>(Condition, description);
+        }
+
         public static IPredicate<T> HavePropertyMemberWithName(string name)
         {
             return new SimplePredicate<T>(type => type.HasPropertyMemberWithName(name),
@@ -332,6 +346,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
                         //ignore, can't be equal anyways
                     }
                 }
+
                 return ruleTypes.Except(archUnitTypeList.OfType<T>());
             }
 
@@ -466,6 +481,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
                         //ignore, can't have a dependency anyways
                     }
                 }
+
                 return ruleTypes.Where(type => !type.GetAssignableTypes().Intersect(archUnitTypeList).Any());
             }
 
@@ -527,6 +543,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
                     //can't have a dependency
                     return ruleTypes;
                 }
+
                 return ruleTypes.Where(type => !type.ImplementsInterface(archUnitInterface));
             }
 
@@ -560,6 +577,21 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
                 (current, asm) => current + " or \"" + asm.FullName + "\"");
 
             return new ArchitecturePredicate<T>(Condition, description);
+        }
+
+        public static IPredicate<T> DoNotResideInAssembly(Domain.Assembly assembly,
+            params Domain.Assembly[] moreAssemblies)
+        {
+            IEnumerable<T> Condition(IEnumerable<T> types)
+            {
+                var assemblyList = moreAssemblies.Concat(new[] {assembly});
+                return types.Where(type => !assemblyList.Contains(type.Assembly));
+            }
+
+            var description = moreAssemblies.Aggregate("do not reside in assembly \"" + assembly.FullName + "\"",
+                (current, asm) => current + " or \"" + asm.FullName + "\"");
+
+            return new EnumerablePredicate<T>(Condition, description);
         }
 
         public static IPredicate<T> DoNotHavePropertyMemberWithName(string name)

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/TypesShould.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/TypesShould.cs
@@ -80,7 +80,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             _ruleCreator.AddCondition(TypeConditionsDefinition<TRuleType>.BeAssignableTo(types));
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
-        
+
         public TRuleTypeShouldConjunction BeValueTypes()
         {
             _ruleCreator.AddCondition(TypeConditionsDefinition<TRuleType>.BeValueTypes());
@@ -135,6 +135,14 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         }
 
         public TRuleTypeShouldConjunction ResideInAssembly(Assembly assembly, params Assembly[] moreAssemblies)
+        {
+            _ruleCreator.AddCondition(
+                TypeConditionsDefinition<TRuleType>.ResideInAssembly(assembly, moreAssemblies));
+            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
+        }
+
+        public TRuleTypeShouldConjunction ResideInAssembly(Domain.Assembly assembly,
+            params Domain.Assembly[] moreAssemblies)
         {
             _ruleCreator.AddCondition(
                 TypeConditionsDefinition<TRuleType>.ResideInAssembly(assembly, moreAssemblies));
@@ -296,6 +304,13 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         }
 
         public TRuleTypeShouldConjunction NotResideInAssembly(Assembly assembly, params Assembly[] moreAssemblies)
+        {
+            _ruleCreator.AddCondition(
+                TypeConditionsDefinition<TRuleType>.NotResideInAssembly(assembly, moreAssemblies));
+            return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
+        }
+        
+        public TRuleTypeShouldConjunction NotResideInAssembly(Domain.Assembly assembly, params Domain.Assembly[] moreAssemblies)
         {
             _ruleCreator.AddCondition(
                 TypeConditionsDefinition<TRuleType>.NotResideInAssembly(assembly, moreAssemblies));

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/TypeSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/TypeSyntaxElementsTests.cs
@@ -93,10 +93,10 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
         [Fact]
         public void AssignableToTest()
         {
-            var falseTypeList1 = new List<Type> { typeof(PublicTestClass), typeof(InternalTestClass) };
-            var falseTypeList2 = new List<IType> { StaticTestTypes.PublicTestClass, StaticTestTypes.InternalTestClass };
+            var falseTypeList1 = new List<Type> {typeof(PublicTestClass), typeof(InternalTestClass)};
+            var falseTypeList2 = new List<IType> {StaticTestTypes.PublicTestClass, StaticTestTypes.InternalTestClass};
             var falseTypeListPattern = new List<string>
-                { StaticTestTypes.PublicTestClass.FullName, StaticTestTypes.InternalTestClass.FullName };
+                {StaticTestTypes.PublicTestClass.FullName, StaticTestTypes.InternalTestClass.FullName};
             foreach (var type in _types)
             {
                 //One Argument
@@ -365,22 +365,51 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
         {
             foreach (var type in _types)
             {
-                var typeResidesInOwnAssembly =
-                    Types().That().Are(type).Should().ResideInAssembly(type.Assembly.FullName);
-                var typeDoesNotResideInOwnAssembly =
-                    Types().That().Are(type).Should().NotResideInAssembly(type.Assembly.FullName);
-                var thereAreTypesInOwnAssembly =
-                    Types().That().ResideInAssembly(type.Assembly.FullName).Should().Exist();
-                var typesInOtherAssemblyAreOtherTypes =
-                    Types().That().DoNotResideInAssembly(type.Assembly.FullName).Should().NotBe(type);
+                {
+                    var typeResidesInOwnAssembly =
+                        Types().That().Are(type).Should().ResideInAssembly(type.Assembly.FullName);
+                    var typeDoesNotResideInOwnAssembly =
+                        Types().That().Are(type).Should().NotResideInAssembly(type.Assembly.FullName);
+                    var thereAreTypesInOwnAssembly =
+                        Types().That().ResideInAssembly(type.Assembly.FullName).Should().Exist();
+                    var typesInOtherAssemblyAreOtherTypes =
+                        Types().That().DoNotResideInAssembly(type.Assembly.FullName).Should().NotBe(type);
 
-                Assert.True(typeResidesInOwnAssembly.HasNoViolations(Architecture));
-                Assert.False(typeDoesNotResideInOwnAssembly.HasNoViolations(Architecture));
-                Assert.True(thereAreTypesInOwnAssembly.HasNoViolations(Architecture));
-                Assert.True(typesInOtherAssemblyAreOtherTypes.HasNoViolations(Architecture));
+                    Assert.True(typeResidesInOwnAssembly.HasNoViolations(Architecture));
+                    Assert.False(typeDoesNotResideInOwnAssembly.HasNoViolations(Architecture));
+                    Assert.True(thereAreTypesInOwnAssembly.HasNoViolations(Architecture));
+                    Assert.True(typesInOtherAssemblyAreOtherTypes.HasNoViolations(Architecture));
+                }
+
+                {
+                    var typeResidesInOwnAssembly =
+                        Types().That().Are(type).Should().ResideInAssembly(type.Assembly);
+                    var typeDoesNotResideInOwnAssembly =
+                        Types().That().Are(type).Should().NotResideInAssembly(type.Assembly);
+                    var thereAreTypesInOwnAssembly =
+                        Types().That().ResideInAssembly(type.Assembly).Should().Exist();
+                    var typesInOtherAssemblyAreOtherTypes =
+                        Types().That().DoNotResideInAssembly(type.Assembly).Should().NotBe(type);
+
+                    Assert.True(typeResidesInOwnAssembly.HasNoViolations(Architecture));
+                    Assert.False(typeDoesNotResideInOwnAssembly.HasNoViolations(Architecture));
+                    Assert.True(thereAreTypesInOwnAssembly.HasNoViolations(Architecture));
+                    Assert.True(typesInOtherAssemblyAreOtherTypes.HasNoViolations(Architecture));
+                }
             }
 
             foreach (var assembly in Architecture.Assemblies.Select(assembly => assembly.FullName))
+            {
+                var typesInAssemblyAreInAssembly =
+                    Types().That().ResideInAssembly(assembly).Should().ResideInAssembly(assembly);
+                var typesInOtherAssemblyAreInOtherAssembly = Types().That().DoNotResideInAssembly(assembly).Should()
+                    .NotResideInAssembly(assembly);
+
+                Assert.True(typesInAssemblyAreInAssembly.HasNoViolations(Architecture));
+                Assert.True(typesInOtherAssemblyAreInOtherAssembly.HasNoViolations(Architecture));
+            }
+            
+            foreach (var assembly in Architecture.Assemblies)
             {
                 var typesInAssemblyAreInAssembly =
                     Types().That().ResideInAssembly(assembly).Should().ResideInAssembly(assembly);


### PR DESCRIPTION
 enhances ResideInAssembly() as requested in #131 