### PR TITLE
Add example rules for testing the target framework of an Architecture

### DIFF
--- a/ArchUnitNET/Domain/Extensions/AssemblyExtensions.cs
+++ b/ArchUnitNET/Domain/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,41 @@
+﻿//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+// 
+// 	SPDX-License-Identifier: Apache-2.0
+// 
+
+using System.Linq;
+using System.Runtime.Versioning;
+
+namespace ArchUnitNET.Domain.Extensions
+{
+    public static class AssemblyExtensions
+    {
+        public static bool IsDotNetStandard(this Assembly assembly)
+        {
+            return assembly.Name.StartsWith("netstandard") ||  assembly.GetTargetFramework().StartsWith(".NETStandard");
+        }
+
+        public static bool IsDotNetCore(this Assembly assembly)
+        {
+            return assembly.GetTargetFramework().StartsWith(".NETCore");
+        }
+        
+        public static bool IsDotNetFramework(this Assembly assembly)
+        {
+            return assembly.Name.StartsWith("mscorlib") ||  assembly.GetTargetFramework().StartsWith(".NETFramework");
+        }
+
+        public static string GetTargetFramework(this Assembly assembly)
+        {
+            var targetFrameworkAttribute = assembly.AttributeInstances.FirstOrDefault(att =>
+                att.Type.FullName == typeof(TargetFrameworkAttribute).FullName);
+
+            var frameworkNameAttribute = targetFrameworkAttribute?.AttributeArguments.FirstOrDefault(argument =>
+                !(argument is AttributeNamedArgument namedArgument) || namedArgument.Name != "FrameworkDisplayName");
+
+            return frameworkNameAttribute?.Value as string ?? "";
+        }
+    }
+}

--- a/ArchUnitNET/Fluent/CustomArchRule.cs
+++ b/ArchUnitNET/Fluent/CustomArchRule.cs
@@ -1,0 +1,58 @@
+﻿//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+// 
+// 	SPDX-License-Identifier: Apache-2.0
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ArchUnitNET.Domain;
+
+namespace ArchUnitNET.Fluent
+{
+    public class CustomArchRule : IArchRule
+    {
+        public string Description { get; }
+
+        private readonly Func<Architecture, IArchRule, IEnumerable<EvaluationResult>> _evaluationFunc;
+
+        public CustomArchRule(Func<Architecture, IArchRule, IEnumerable<EvaluationResult>> evaluationFunc,
+            string description)
+        {
+            _evaluationFunc = evaluationFunc;
+            Description = description;
+        }
+
+        public bool HasNoViolations(Architecture architecture)
+        {
+            return Evaluate(architecture).All(result => result.Passed);
+        }
+
+        public IEnumerable<EvaluationResult> Evaluate(Architecture architecture)
+        {
+            return _evaluationFunc.Invoke(architecture, this);
+        }
+
+        public CombinedArchRuleDefinition And()
+        {
+            return new CombinedArchRuleDefinition(this, LogicalConjunctionDefinition.And);
+        }
+
+        public CombinedArchRuleDefinition Or()
+        {
+            return new CombinedArchRuleDefinition(this, LogicalConjunctionDefinition.Or);
+        }
+
+        public IArchRule And(IArchRule archRule)
+        {
+            return new CombinedArchRule(this, LogicalConjunctionDefinition.And, archRule);
+        }
+
+        public IArchRule Or(IArchRule archRule)
+        {
+            return new CombinedArchRule(this, LogicalConjunctionDefinition.Or, archRule);
+        }
+    }
+}

--- a/ArchUnitNET/Library/Rules/TargetFrameworkRules.cs
+++ b/ArchUnitNET/Library/Rules/TargetFrameworkRules.cs
@@ -1,0 +1,65 @@
+﻿//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+// 
+// 	SPDX-License-Identifier: Apache-2.0
+// 
+
+using System.Collections.Generic;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Domain.Extensions;
+using ArchUnitNET.Fluent;
+
+namespace ArchUnitNET.Library.Rules
+{
+    public static class TargetFrameworkRules
+    {
+        public static IArchRule ShouldBeDotNetStandard()
+        {
+            IEnumerable<EvaluationResult> Evaluate(Architecture architecture, IArchRule archRule)
+            {
+                foreach (var assembly in architecture.Assemblies)
+                {
+                    var passed = assembly.IsDotNetStandard();
+                    var description = "has target framework " + assembly.GetTargetFramework();
+                    yield return new EvaluationResult(assembly, new StringIdentifier(assembly.FullName), passed,
+                        description, archRule, architecture);
+                }
+            }
+
+            return new CustomArchRule(Evaluate, "Should be .Net Standard");
+        }
+
+        public static IArchRule ShouldBeDotNetCore()
+        {
+            IEnumerable<EvaluationResult> Evaluate(Architecture architecture, IArchRule archRule)
+            {
+                foreach (var assembly in architecture.Assemblies)
+                {
+                    var passed = assembly.IsDotNetCore();
+                    var description = "has target framework " + assembly.GetTargetFramework();
+                    yield return new EvaluationResult(assembly, new StringIdentifier(assembly.FullName), passed,
+                        description, archRule, architecture);
+                }
+            }
+
+            return new CustomArchRule(Evaluate, "Should be .Net Core");
+        }
+
+        public static IArchRule ShouldBeDotNetFramework()
+        {
+            IEnumerable<EvaluationResult> Evaluate(Architecture architecture, IArchRule archRule)
+            {
+                foreach (var assembly in architecture.Assemblies)
+                {
+                    var passed = assembly.IsDotNetFramework();
+                    var description = "has target framework " + assembly.GetTargetFramework();
+                    yield return new EvaluationResult(assembly, new StringIdentifier(assembly.FullName), passed,
+                        description, archRule, architecture);
+                }
+            }
+
+            return new CustomArchRule(Evaluate, "Should be .Net Framework");
+        }
+    }
+}


### PR DESCRIPTION
Start a library of example rules with 3 examples for checking the target framework of a project.
Inspired by https://gaevoy.com/2022/05/19/review-dependencies-on-every-commit.html