### PR TITLE
Added LoadAssembliesRecursively with custom load filter function support

### DIFF
--- a/ArchUnitNET/Loader/FilterResult.cs
+++ b/ArchUnitNET/Loader/FilterResult.cs
@@ -1,0 +1,53 @@
+//  Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+// 
+// 	SPDX-License-Identifier: Apache-2.0
+// 
+
+using Mono.Cecil;
+
+namespace ArchUnitNET.Loader
+{
+    /// <summary>
+    /// Type of delegate to control assemblies loading
+    /// </summary>
+    /// <param name="assemblyDefinition">Current assembly definition</param>
+    public delegate FilterResult FilterFunc(AssemblyDefinition assemblyDefinition);
+    
+    /// <summary>
+    /// Filter function result options
+    /// </summary>
+    public struct FilterResult
+    {
+        /// <summary>
+        /// Load this assembly and traverse its dependencies
+        /// </summary>
+        public static FilterResult LoadAndContinue = new FilterResult(true, true);
+        
+        /// <summary>
+        /// Do not load this assembly, but traverse its dependencies
+        /// </summary>
+        public static FilterResult SkipAndContinue = new FilterResult(true, false);
+        
+        /// <summary>
+        /// Load this assembly and do not traverse its dependencies
+        /// </summary>
+        public static FilterResult LoadAndStop = new FilterResult(false, true);
+        
+        /// <summary>
+        /// Do not load this assembly and do not traverse its dependencies
+        /// </summary>
+        public static FilterResult DontLoadAndStop = new FilterResult(false, false);
+        
+        private FilterResult(bool traverseDependencies, bool loadThisAssembly)
+        {
+            TraverseDependencies = traverseDependencies;
+            LoadThisAssembly = loadThisAssembly;
+        }
+
+        internal bool TraverseDependencies { get; }
+        
+        internal bool LoadThisAssembly { get; }
+    }
+}

--- a/ArchUnitNETTests/Loader/ArchLoaderTests.cs
+++ b/ArchUnitNETTests/Loader/ArchLoaderTests.cs
@@ -34,5 +34,31 @@ namespace ArchUnitNETTests.Loader
 
             Assert.True(archUnitNetTestArchitectureWithRecursiveDependencies.Assemblies.Count() > 100);
         }
+
+        [Fact]
+        public void LoadAssembliesRecursivelyWithCustomFilter()
+        {
+            FilterFunc filterFunc = assembly => assembly.Name.Name.StartsWith("ArchUnit") ? FilterResult.LoadAndContinue : FilterResult.DontLoadAndStop;
+            var loader = new ArchLoader();
+            var architecture = loader.LoadAssembliesRecursively(new[] { typeof(BaseClass).Assembly }, filterFunc).Build();
+            
+            Assert.Equal(3, architecture.Assemblies.Count());
+        }
+        
+        [Fact]
+        public void LoadAssembliesRecursively_NestedDependencyOnly()
+        {
+            FilterFunc filterFunc = assembly =>
+            { 
+                if (assembly.Name.Name == "ArchUnitNet")
+                    return FilterResult.LoadAndStop;
+                        
+                return FilterResult.SkipAndContinue;
+            };
+            var loader = new ArchLoader();
+            var architecture = loader.LoadAssembliesRecursively(new[] { typeof(BaseClass).Assembly }, filterFunc).Build();
+            
+            Assert.Equal(1, architecture.Assemblies.Count());
+        }
     }
 }


### PR DESCRIPTION
Should resolve https://github.com/TNG/ArchUnitNET/issues/164
Added new overload with custom filter delegate. This delegate is passed through LoadModule to AddReferencedAssembliesRecursively. I've decided to reuse existing private methods, and add delegate as new argument with default value = null. When the delegate is null methods behavior should remain exactly as it was before.