### PR TITLE
chore change example and test how to load assemblies 

### DIFF
--- a/ArchUnitNET.MSTestV2Tests/RuleEvaluationTests.cs
+++ b/ArchUnitNET.MSTestV2Tests/RuleEvaluationTests.cs
@@ -25,7 +25,7 @@ namespace ArchUnitNET.MSTestV2Tests
         [ClassInitialize]
         public static void Setup(TestContext context)
         {
-            _architecture = new ArchLoader().LoadAssemblies(typeof(RuleEvaluationTests).Assembly).Build();
+            _architecture = new ArchLoader().LoadAssemblies(System.Reflection.Assembly.Load("ArchUnitNET.MSTestV2Tests")).Build();
             _trueRule = Classes().That().Are(typeof(RuleEvaluationTests)).Should().Exist();
             _falseRule = Classes().That().Are(typeof(RuleEvaluationTests)).Should().NotExist();
             _expectedErrorMessage = _falseRule.Evaluate(_architecture).ToErrorMessage();

--- a/ArchUnitNET.NUnitTests/RuleEvaluationTests.cs
+++ b/ArchUnitNET.NUnitTests/RuleEvaluationTests.cs
@@ -24,7 +24,7 @@ namespace ArchUnitNET.NUnitTests
         [SetUp]
         public void Setup()
         {
-            _architecture = new ArchLoader().LoadAssemblies(typeof(RuleEvaluationTests).Assembly).Build();
+            _architecture = new ArchLoader().LoadAssemblies(System.Reflection.Assembly.Load("ArchUnitNET.NUnitTests")).Build();
             _trueRule = Classes().That().Are(typeof(RuleEvaluationTests)).Should().Exist();
             _falseRule = Classes().That().Are(typeof(RuleEvaluationTests)).Should().NotExist();
             _expectedErrorMessage = _falseRule.Evaluate(_architecture).ToErrorMessage();

--- a/ArchUnitNETTests/Dependencies/ExternalDependenciesTests.cs
+++ b/ArchUnitNETTests/Dependencies/ExternalDependenciesTests.cs
@@ -18,9 +18,10 @@ namespace ArchUnitNETTests.Dependencies
         private static readonly Architecture Architecture =
             new ArchLoader().LoadAssembly(typeof(ExternalDependenciesTests).Assembly).Build();
 
-        private static readonly Architecture ArchitectureBothAssemblies =
-            new ArchLoader().LoadAssemblies(typeof(ExternalDependenciesTests).Assembly, typeof(Class2).Assembly)
-                .Build();
+        private static readonly Architecture ArchitectureBothAssemblies = new ArchLoader().LoadAssemblies(
+            System.Reflection.Assembly.Load("ArchUnitNETTests"),
+            System.Reflection.Assembly.Load("TestAssembly"))
+            .Build();
 
         private static readonly Architecture ArchitectureExternalDependency =
             new ArchLoader().LoadAssemblyIncludingDependencies(typeof(ExternalDependenciesTests).Assembly).Build();

--- a/ArchUnitNETTests/Domain/Dependencies/Members/GetterSetterTestsBuild.cs
+++ b/ArchUnitNETTests/Domain/Dependencies/Members/GetterSetterTestsBuild.cs
@@ -21,7 +21,7 @@ namespace ArchUnitNETTests.Domain.Dependencies.Members
     public class GetterSetterTestsBuild
     {
         private static readonly Architecture Architecture =
-            new ArchLoader().LoadAssemblies(typeof(GetterMethodDependencyExamples).Assembly).Build();
+            new ArchLoader().LoadAssemblies(System.Reflection.Assembly.Load("ArchUnitNETTests")).Build();
 
         private static readonly Type GuidType = typeof(Guid);
         private static readonly IType MockGuidStruct = GuidType.CreateStubIType();

--- a/ArchUnitNETTests/Fluent/MultipleConditionRulesTests.cs
+++ b/ArchUnitNETTests/Fluent/MultipleConditionRulesTests.cs
@@ -18,7 +18,7 @@ namespace ArchUnitNETTests.Fluent
     public class MultipleConditionRulesTests
     {
         private static readonly Architecture Architecture =
-            new ArchLoader().LoadAssemblies(typeof(MultipleConditionRulesTests).Assembly).Build();
+            new ArchLoader().LoadAssemblies(System.Reflection.Assembly.Load("ArchUnitNETTests")).Build();
 
         private readonly Class _failingClass;
 

--- a/ArchUnitNETTests/Fluent/NoErrorReferencingOfTypesOutsideOfArchitectureTests.cs
+++ b/ArchUnitNETTests/Fluent/NoErrorReferencingOfTypesOutsideOfArchitectureTests.cs
@@ -21,7 +21,7 @@ namespace ArchUnitNETTests.Fluent
     public class NoErrorReferencingOfTypesOutsideOfArchitectureTests
     {
         private static readonly Architecture Architecture =
-            new ArchLoader().LoadAssemblies(typeof(EmptyTestClass).Assembly).Build();
+            new ArchLoader().LoadAssemblies(System.Reflection.Assembly.Load("TestAssembly")).Build();
 
         private readonly System.Type _classNotInArchitecture = typeof(NoErrorReferencingOfTypesOutsideOfArchitectureTests);
 

--- a/ArchUnitNETTests/Fluent/Syntax/DependenciesToOtherAssembliesTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/DependenciesToOtherAssembliesTests.cs
@@ -20,7 +20,7 @@ namespace ArchUnitNETTests.Fluent.Syntax
         public class TestDependencyIssue
         {
             private static readonly Architecture Architecture =
-                new ArchLoader().LoadAssemblies(typeof(DependenciesToOtherAssembliesTests).Assembly).Build();
+                new ArchLoader().LoadAssemblies(System.Reflection.Assembly.Load("ArchUnitNETTests")).Build();
 
             [Fact]
             public void DependOnAnyTypesThatTest()

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/CustomSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/CustomSyntaxElementsTests.cs
@@ -18,7 +18,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
     public class CustomSyntaxElementsTests
     {
         private static readonly Architecture Architecture =
-            new ArchLoader().LoadAssemblies(typeof(CustomSyntaxElementsTests).Assembly).Build();
+            new ArchLoader().LoadAssemblies(System.Reflection.Assembly.Load("ArchUnitNETTests")).Build();
 
         private readonly Class _testClass;
 

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/MatchGenericReturnTypesTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/MatchGenericReturnTypesTests.cs
@@ -16,7 +16,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
     public class MatchGenericReturnTypesTests
     {
         private static readonly Architecture Architecture =
-            new ArchLoader().LoadAssemblies(typeof(MatchGenericReturnTypesTests).Assembly).Build();
+            new ArchLoader().LoadAssemblies(System.Reflection.Assembly.Load("ArchUnitNETTests")).Build();
 
         [Fact]
         public void OneGenericParameter()

--- a/ArchUnitNETTests/Loader/NestedTypesTests.cs
+++ b/ArchUnitNETTests/Loader/NestedTypesTests.cs
@@ -16,7 +16,7 @@ namespace ArchUnitNETTests.Loader
     public class NestedTypesTests
     {
         private static readonly Architecture Architecture =
-            new ArchLoader().LoadAssemblies(typeof(NestedTypesTests).Assembly).Build();
+            new ArchLoader().LoadAssemblies(System.Reflection.Assembly.Load("ArchUnitNETTests")).Build();
 
         [Fact]
         public void FindAllNestedTypes()

--- a/ExampleTest/ExampleArchUnitTest.cs
+++ b/ExampleTest/ExampleArchUnitTest.cs
@@ -21,8 +21,9 @@ namespace ExampleTest
     public class ExampleArchUnitTest
     {
         // TIP: load your architecture once at the start to maximize performance of your tests
-        private static readonly Architecture Architecture =
-            new ArchLoader().LoadAssemblies(typeof(ExampleClass).Assembly, typeof(ForbiddenClass).Assembly).Build();
+        private static readonly Architecture Architecture = new ArchLoader().LoadAssemblies(
+            System.Reflection.Assembly.Load("TestAssembly"))
+            .Build();
         // replace <ExampleClass> and <ForbiddenClass> with classes from the assemblies you want to test
 
         //declare variables you'll use throughout your tests up here
@@ -85,6 +86,7 @@ namespace ExampleTest
         }
     }
 }
+
 
 internal class ExampleClass
 {

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ namespace ExampleTest
     public class ExampleArchUnitTest
     {
         // TIP: load your architecture once at the start to maximize performance of your tests
-        private static readonly Architecture Architecture =
-            new ArchLoader().LoadAssemblies(typeof(ExampleClass).Assembly, typeof(ForbiddenClass).Assembly)
+        private static readonly Architecture Architecture = new ArchLoader().LoadAssemblies(
+                System.Reflection.Assembly.Load("ExampleClassAssemblyName")
+                System.Reflection.Assembly.Load("ForbiddenClassAssemblyName")
             .Build();
         // replace <ExampleClass> and <ForbiddenClass> with classes from the assemblies you want to test
 

--- a/documentation/docs/guide.md
+++ b/documentation/docs/guide.md
@@ -36,8 +36,8 @@ replace <ExampleClass\> and <ForbiddenClass\> with classes from the assemblies y
 ```cs
 private static readonly Architecture Architecture =
     new ArchLoader().LoadAssemblies(
-        typeof(ExampleClass).Assembly, 
-        typeof(ForbiddenClass).Assembly
+        System.Reflection.Assembly.Load("ExampleClassAssemblyName"),
+        System.Reflection.Assembly.Load("ForbiddenClassAssemblyName")
     ).Build();
 ```
 #### 2.3. Declare Layers


### PR DESCRIPTION
Related to: `Question: Load assemblies example` #177 

this will make the test more robust in case you move classes to other assembly which could break your architecture without detecting with the tests.
