### PR TITLE
Update dependency dotnet-sdk to v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ solution: ArchUnit.sln
 jobs:
   include:
     - stage: linux_build
-      dotnet: 5.0.203
+      dotnet: 6.0.402
       mono: none
       os: linux
       script: chmod +x ./Travis/test_linux.sh && ./Travis/test_linux.sh
@@ -20,7 +20,7 @@ jobs:
       mono: none
       os: windows
       before_script:
-        - choco install dotnet-5.0-sdk --version=5.0.203
+        - choco install dotnet-6.0-sdk --version=6.0.402
         - PowerShell -Command 'Set-ExecutionPolicy -ExecutionPolicy RemoteSigned'
       script:
         - PowerShell -File Travis/test_windows.ps1 -tag "$TRAVIS_TAG"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.203",
+    "version": "6.0.402",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
Signed-off-by: Andrii Derevianko <andredered@gmail.com>
NET SDK to v6.0.402 in travis.yml and global.json update