### PR TITLE
Require positive results by default

### DIFF
--- a/ArchUnitNET/Fluent/ArchRuleCreator.cs
+++ b/ArchUnitNET/Fluent/ArchRuleCreator.cs
@@ -4,6 +4,7 @@
 // 
 // 	SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ArchUnitNET.Domain;
@@ -16,6 +17,7 @@ namespace ArchUnitNET.Fluent
     {
         private readonly ConditionManager<TRuleType> _conditionManager;
         private readonly PredicateManager<TRuleType> _predicateManager;
+        private bool? _requirePositiveResults;
 
         public ArchRuleCreator(BasicObjectProvider<TRuleType> basicObjectProvider)
         {
@@ -91,6 +93,20 @@ namespace ArchUnitNET.Fluent
         public void SetCustomConditionDescription(string description)
         {
             _conditionManager.SetCustomDescription(description);
+        }
+
+        private void SetRequirePositiveResults(bool requirePositive)
+        {
+            if (_requirePositiveResults != null &&
+                _requirePositiveResults != requirePositive)
+                throw new InvalidOperationException("conflicting positive expectation");
+            _requirePositiveResults = requirePositive;
+        }
+
+        public bool RequirePositiveResults
+        {
+            get => _requirePositiveResults ?? true;
+            set => SetRequirePositiveResults(value);
         }
 
         private bool HasNoViolations(IEnumerable<TRuleType> filteredObjects, Architecture architecture)

--- a/ArchUnitNET/Fluent/CombinedArchRuleCreator.cs
+++ b/ArchUnitNET/Fluent/CombinedArchRuleCreator.cs
@@ -4,6 +4,7 @@
 // 
 // 	SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ArchUnitNET.Domain;
@@ -18,6 +19,7 @@ namespace ArchUnitNET.Fluent
         private readonly ArchRuleCreator<TRuleType> _currentArchRuleCreator;
         private readonly LogicalConjunction _logicalConjunction;
         private readonly ICanBeEvaluated _oldRule;
+        private bool? _requirePositiveResults;
 
         public CombinedArchRuleCreator(ICanBeEvaluated oldRule, LogicalConjunction logicalConjunction,
             BasicObjectProvider<TRuleType> basicObjectProvider)
@@ -98,6 +100,21 @@ namespace ArchUnitNET.Fluent
         {
             _currentArchRuleCreator.SetCustomConditionDescription(description);
         }
+
+        private void SetRequirePositiveResults(bool requirePositive)
+        {
+            if (_requirePositiveResults != null &&
+                _requirePositiveResults != requirePositive)
+                throw new InvalidOperationException("conflicting positive expectation");
+            _requirePositiveResults = requirePositive;
+        }
+
+        public bool RequirePositiveResults
+        {
+            get => _requirePositiveResults ?? true;
+            set => SetRequirePositiveResults(value);
+        }
+
 
         public override string ToString()
         {

--- a/ArchUnitNET/Fluent/ConditionManager.cs
+++ b/ArchUnitNET/Fluent/ConditionManager.cs
@@ -90,9 +90,10 @@ namespace ArchUnitNET.Fluent
             Architecture architecture, ICanBeEvaluated archRuleCreator)
         {
             var filteredObjectsList = filteredObjects.ToList();
-            if (filteredObjectsList.IsNullOrEmpty())
+            if (filteredObjectsList.IsNullOrEmpty() &&
+                !CheckEmpty())
             {
-                yield return new EvaluationResult(null, new StringIdentifier(""), CheckEmpty(),
+                yield return new EvaluationResult(null, new StringIdentifier(""), false,
                     "There are no objects matching the criteria", archRuleCreator, architecture);
                 yield break;
             }

--- a/ArchUnitNET/Fluent/IArchRuleCreator.cs
+++ b/ArchUnitNET/Fluent/IArchRuleCreator.cs
@@ -31,5 +31,7 @@ namespace ArchUnitNET.Fluent
 
         void SetCustomPredicateDescription(string description);
         void SetCustomConditionDescription(string description);
+
+        bool RequirePositiveResults { get; set; }
     }
 }

--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectsShould.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectsShould.cs
@@ -27,6 +27,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
 
         public TRuleTypeShouldConjunction Exist()
         {
+            _ruleCreator.RequirePositiveResults = false;
             _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.Exist());
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }
@@ -545,6 +546,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
 
         public TRuleTypeShouldConjunction NotExist()
         {
+            _ruleCreator.RequirePositiveResults = false;
             _ruleCreator.AddCondition(ObjectConditionsDefinition<TRuleType>.NotExist());
             return Create<TRuleTypeShouldConjunction, TRuleType>(_ruleCreator);
         }

--- a/ArchUnitNETTests/Fluent/RuleEvaluationTests.cs
+++ b/ArchUnitNETTests/Fluent/RuleEvaluationTests.cs
@@ -51,6 +51,10 @@ namespace ArchUnitNETTests.Fluent
         private static readonly IArchRule WrongArchRule1AndWrongArchRule3 = WrongArchRule1.And(WrongArchRule3);
         private static readonly IArchRule WrongArchRule4AndWrongArchRule8 = WrongArchRule4.And(WrongArchRule8);
 
+        private static readonly IArchRule WrongArchRule9 =
+            Classes().That().HaveName(NoClassName).Should().BePrivate();
+
+
         private readonly string _expectedWrongArchRule1AndWrongArchRule3ErrorMessage =
             "\"Classes that are \"ArchUnitNETTests.Domain.PublicTestClass\" should be private\" failed:" +
             NewLine + "\tArchUnitNETTests.Domain.PublicTestClass is public" + NewLine +
@@ -108,6 +112,10 @@ namespace ArchUnitNETTests.Fluent
             NewLine + "\tArchUnitNETTests.Domain.PublicTestClass does exist and is public" +
             NewLine + NewLine;
 
+        private readonly string _expectedWrongArchRule9ErrorMessage = "\"Classes that have name \"NotTheNameOfAnyClass_1592479214\" should be private\" failed:" + NewLine +
+          "\tThe rule requires positive evaluation, not just absence of violations. Use WithoutRequiringPositiveResults() or improve your rule's predicates." +
+          NewLine + NewLine;
+
         [Fact]
         public void AssertArchRuleTest()
         {
@@ -133,6 +141,8 @@ namespace ArchUnitNETTests.Fluent
                 ArchRuleAssert.CheckRule(Architecture, WrongArchRule1AndWrongArchRule3));
             var exception4And8 = Assert.Throws<FailedArchRuleException>(() =>
                 ArchRuleAssert.CheckRule(Architecture, WrongArchRule4AndWrongArchRule8));
+            var exception9 =
+                Assert.Throws<FailedArchRuleException>(() => ArchRuleAssert.CheckRule(Architecture, WrongArchRule9));
 
             Assert.Equal(_expectedWrongArchRule1ErrorMessage, exception1.Message);
             Assert.Equal(_expectedWrongArchRule2ErrorMessage, exception2.Message);
@@ -144,6 +154,8 @@ namespace ArchUnitNETTests.Fluent
             Assert.Equal(_expectedWrongArchRule8ErrorMessage, exception8.Message);
             Assert.Equal(_expectedWrongArchRule1AndWrongArchRule3ErrorMessage, exception1And3.Message);
             Assert.Equal(_expectedWrongArchRule4AndWrongArchRule8ErrorMessage, exception4And8.Message);
+            Assert.Equal(_expectedWrongArchRule9ErrorMessage, exception9.Message);
+
         }
 
         [Fact]

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/MemberSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/MemberSyntaxElementsTests.cs
@@ -101,9 +101,9 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
 
             foreach (var type in _types)
             {
-                var membersShouldBeDeclaredInOwnType = Members().That().AreDeclaredIn(type).Should().BeDeclaredIn(type);
+                var membersShouldBeDeclaredInOwnType = Members().That().AreDeclaredIn(type).Should().BeDeclaredIn(type).WithoutRequiringPositiveResults();
                 var membersShouldNotBeDeclaredInOwnType =
-                    Members().That().AreNotDeclaredIn(type).Should().BeDeclaredIn(type);
+                    Members().That().AreNotDeclaredIn(type).Should().BeDeclaredIn(type).WithoutRequiringPositiveResults();
 
                 Assert.True(membersShouldBeDeclaredInOwnType.HasNoViolations(Architecture));
                 Assert.False(membersShouldNotBeDeclaredInOwnType.HasNoViolations(Architecture));

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/MethodMemberSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/MethodMemberSyntaxElementsTests.cs
@@ -81,7 +81,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
                     notVirtualMethodMembersDoNotIncludeMember.HasNoViolations(Architecture));
             }
 
-            var virtualMethodMembersShouldBeVirtual = MethodMembers().That().AreVirtual().Should().BeVirtual();
+            var virtualMethodMembersShouldBeVirtual = MethodMembers().That().AreVirtual().Should().BeVirtual().WithoutRequiringPositiveResults();
             var virtualMethodMembersAreNotVirtual =
                 MethodMembers().That().AreVirtual().Should().NotBeVirtual().AndShould().Exist();
             var notVirtualMethodMembersShouldBeVirtual =
@@ -124,7 +124,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             foreach (var type in _types)
             {
                 var calledMethodsShouldBeCalled = MethodMembers().That().AreCalledBy(type.FullName).Should()
-                    .BeCalledBy(type.FullName);
+                    .BeCalledBy(type.FullName).WithoutRequiringPositiveResults();
                 var notCalledMethodsShouldNotBeCalled = MethodMembers().That().AreNotCalledBy(type.FullName).Should()
                     .NotBeCalledBy(type.FullName);
 
@@ -164,7 +164,8 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             {
                 var dependentMethodsShouldBeDependent = MethodMembers().That()
                     .HaveDependencyInMethodBodyTo(type.FullName).Should()
-                    .HaveDependencyInMethodBodyTo(type.FullName);
+                    .HaveDependencyInMethodBodyTo(type.FullName)
+                    .WithoutRequiringPositiveResults();
                 var notDependentMethodsShouldNotBeDependent = MethodMembers().That()
                     .DoNotHaveDependencyInMethodBodyTo(type.FullName).Should()
                     .NotHaveDependencyInMethodBodyTo(type.FullName);
@@ -259,8 +260,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
         {
             var stringReturnTypes = new List<string> {"void", "string"};
             var retTypeWithString = MethodMembers().That().HaveFullNameContaining("ReturnTypeMethod").And()
-                .HaveReturnType(stringReturnTypes, true).Should().HaveFullNameContaining("Void").OrShould()
-                .HaveFullNameContaining("String");
+                .HaveReturnType(stringReturnTypes, true).Should().HaveFullNameContaining("Void").OrShould().HaveFullNameContaining("String").WithoutRequiringPositiveResults();
             var retTypeWithStringNegate = MethodMembers().That().DoNotHaveReturnType("String", true).And()
                 .HaveFullNameContaining("ReturnTypeMethod").Should().NotHaveFullNameContaining("String");
 

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/ObjectSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/ObjectSyntaxElementsTests.cs
@@ -152,11 +152,11 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
 
                 var typesDependOnOwnDependencies =
                     Types().That().DependOnAny(type.FullName).Should()
-                        .DependOnAny(type.FullName);
+                        .DependOnAny(type.FullName).WithoutRequiringPositiveResults();
                 var typeDoesNotDependOnFalseDependency =
                     Types().That().Are(type).Should().NotDependOnAny(NoTypeName);
                 var typeDependsOnFalseDependency =
-                    Types().That().Are(type).Should().DependOnAny(NoTypeName);
+                    Types().That().Are(type).Should().DependOnAny(NoTypeName).WithoutRequiringPositiveResults();
 
                 Assert.True(typesDependOnOwnDependencies.HasNoViolations(Architecture));
                 Assert.True(typeDoesNotDependOnFalseDependency.HasNoViolations(Architecture));
@@ -166,7 +166,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
 
                 var patternList = new List<string> {type.FullName, NoTypeName};
                 var typesDependOnOwnDependenciesMultiple =
-                    Types().That().DependOnAny(patternList).Should().DependOnAny(patternList);
+                    Types().That().DependOnAny(patternList).Should().DependOnAny(patternList).WithoutRequiringPositiveResults();
                 var typeDependsOnFalseDependencyMultiple =
                     Types().That().Are(patternList).Should().DependOnAny(NoTypeName);
 
@@ -196,7 +196,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
                 //One Argument
                 var typeDependencies = type.GetTypeDependencies(Architecture).ToList();
                 var typesDependOnOwnDependencies =
-                    Types().That().DependOnAny(type).Should().DependOnAnyTypesThat().Are(type);
+                    Types().That().DependOnAny(type).Should().DependOnAnyTypesThat().Are(type).WithoutRequiringPositiveResults();
                 var typeDoesNotDependOnOneFalseDependency =
                     Types().That().Are(type).Should().NotDependOnAnyTypesThat().Are(typeof(ClassWithNoDependencies1));
                 var typeDependsOnOneFalseDependency =
@@ -270,7 +270,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
 
                 //One Argument
 
-                var typesDependOnOwnDependencies = Types().That().DependOnAny(type).Should().DependOnAny(type);
+                var typesDependOnOwnDependencies = Types().That().DependOnAny(type).Should().DependOnAny(type).WithoutRequiringPositiveResults();
                 var typeDoesNotDependOnOneFalseDependency =
                     Types().That().Are(type).Should().NotDependOnAny(typeof(ClassWithNoDependencies1));
                 var typeDependsOnOneFalseDependency =

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/PropertyMemberSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/PropertyMemberSyntaxElementsTests.cs
@@ -43,7 +43,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
                     notVirtualPropertyMembersDoNotIncludeMember.HasNoViolations(Architecture));
             }
 
-            var virtualPropertyMembersShouldBeVirtual = PropertyMembers().That().AreVirtual().Should().BeVirtual();
+            var virtualPropertyMembersShouldBeVirtual = PropertyMembers().That().AreVirtual().Should().BeVirtual().WithoutRequiringPositiveResults();
             var virtualPropertyMembersAreNotVirtual =
                 PropertyMembers().That().AreVirtual().Should().NotBeVirtual().AndShould().Exist();
             var notVirtualPropertyMembersShouldBeVirtual =
@@ -119,7 +119,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             }
 
             var propertyMembersWithInternalGetterHaveInternalGetter =
-                PropertyMembers().That().HaveInternalGetter().Should().HaveInternalGetter();
+                PropertyMembers().That().HaveInternalGetter().Should().HaveInternalGetter().WithoutRequiringPositiveResults();
             var propertyMembersWithInternalGetterDoNotHaveInternalGetter =
                 PropertyMembers().That().HaveInternalGetter().Should().NotHaveInternalGetter().AndShould().Exist();
             var propertyMembersWithoutInternalGetterHaveInternalGetter =
@@ -159,7 +159,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             }
 
             var propertyMembersWithInternalSetterHaveInternalSetter =
-                PropertyMembers().That().HaveInternalSetter().Should().HaveInternalSetter();
+                PropertyMembers().That().HaveInternalSetter().Should().HaveInternalSetter().WithoutRequiringPositiveResults();
             var propertyMembersWithInternalSetterDoNotHaveInternalSetter =
                 PropertyMembers().That().HaveInternalSetter().Should().NotHaveInternalSetter().AndShould().Exist();
             var propertyMembersWithoutInternalSetterHaveInternalSetter =
@@ -241,7 +241,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             }
 
             var propertyMembersWithPrivateProtectedGetterHavePrivateProtectedGetter =
-                PropertyMembers().That().HavePrivateProtectedGetter().Should().HavePrivateProtectedGetter();
+                PropertyMembers().That().HavePrivateProtectedGetter().Should().HavePrivateProtectedGetter().WithoutRequiringPositiveResults();
             var propertyMembersWithPrivateProtectedGetterDoNotHavePrivateProtectedGetter =
                 PropertyMembers().That().HavePrivateProtectedGetter().Should().NotHavePrivateProtectedGetter()
                     .AndShould().Exist();
@@ -290,7 +290,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             }
 
             var propertyMembersWithPrivateProtectedSetterHavePrivateProtectedSetter =
-                PropertyMembers().That().HavePrivateProtectedSetter().Should().HavePrivateProtectedSetter();
+                PropertyMembers().That().HavePrivateProtectedSetter().Should().HavePrivateProtectedSetter().WithoutRequiringPositiveResults();
             var propertyMembersWithPrivateProtectedSetterDoNotHavePrivateProtectedSetter =
                 PropertyMembers().That().HavePrivateProtectedSetter().Should().NotHavePrivateProtectedSetter()
                     .AndShould().Exist();
@@ -419,7 +419,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             }
 
             var propertyMembersWithProtectedInternalGetterHaveProtectedInternalGetter =
-                PropertyMembers().That().HaveProtectedInternalGetter().Should().HaveProtectedInternalGetter();
+                PropertyMembers().That().HaveProtectedInternalGetter().Should().HaveProtectedInternalGetter().WithoutRequiringPositiveResults();
             var propertyMembersWithProtectedInternalGetterDoNotHaveProtectedInternalGetter =
                 PropertyMembers().That().HaveProtectedInternalGetter().Should().NotHaveProtectedInternalGetter()
                     .AndShould().Exist();
@@ -469,7 +469,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             }
 
             var propertyMembersWithProtectedInternalSetterHaveProtectedInternalSetter =
-                PropertyMembers().That().HaveProtectedInternalSetter().Should().HaveProtectedInternalSetter();
+                PropertyMembers().That().HaveProtectedInternalSetter().Should().HaveProtectedInternalSetter().WithoutRequiringPositiveResults();
             var propertyMembersWithProtectedInternalSetterDoNotHaveProtectedInternalSetter =
                 PropertyMembers().That().HaveProtectedInternalSetter().Should().NotHaveProtectedInternalSetter()
                     .AndShould().Exist();
@@ -517,7 +517,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             }
 
             var propertyMembersWithProtectedSetterHaveProtectedSetter =
-                PropertyMembers().That().HaveProtectedSetter().Should().HaveProtectedSetter();
+                PropertyMembers().That().HaveProtectedSetter().Should().HaveProtectedSetter().WithoutRequiringPositiveResults();
             var propertyMembersWithProtectedSetterDoNotHaveProtectedSetter =
                 PropertyMembers().That().HaveProtectedSetter().Should().NotHaveProtectedSetter().AndShould().Exist();
             var propertyMembersWithoutProtectedSetterHaveProtectedSetter =

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/TypeSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/TypeSyntaxElementsTests.cs
@@ -339,7 +339,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             {
                 var typesThatImplementInterfaceImplementInterface = Types().That()
                     .ImplementInterface(intf.FullName)
-                    .Should().ImplementInterface(intf.FullName);
+                    .Should().ImplementInterface(intf.FullName).WithoutRequiringPositiveResults();
                 var typesThatImplementInterfaceDoNotImplementInterface = Types().That()
                     .ImplementInterface(intf.FullName).Should()
                     .NotImplementInterface(intf.FullName).AndShould().Exist();
@@ -372,7 +372,8 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
                 .ImplementInterface(InheritedTestInterface.FullName);
             var testClassThatImplementsNoInterfaceDoesNotImplementInterface = Interfaces().That()
                 .Are(StaticTestTypes.PublicTestClass).Should()
-                .NotImplementInterface(InheritedTestInterface.FullName);
+                .NotImplementInterface(InheritedTestInterface.FullName)
+                .WithoutRequiringPositiveResults();
             var testClassThatImplementsNoInterfaceImplementsInterface = Interfaces().That()
                 .Are(StaticTestTypes.PublicTestClass).Should()
                 .ImplementInterface(InheritedTestInterface.FullName).AndShould()
@@ -398,7 +399,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
                     var thereAreTypesInOwnAssembly =
                         Types().That().ResideInAssembly(type.Assembly.FullName).Should().Exist();
                     var typesInOtherAssemblyAreOtherTypes =
-                        Types().That().DoNotResideInAssembly(type.Assembly.FullName).Should().NotBe(type);
+                        Types().That().DoNotResideInAssembly(type.Assembly.FullName).Should().NotBe(type).WithoutRequiringPositiveResults();
 
                     Assert.True(typeResidesInOwnAssembly.HasNoViolations(Architecture));
                     Assert.False(typeDoesNotResideInOwnAssembly.HasNoViolations(Architecture));
@@ -414,7 +415,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
                     var thereAreTypesInOwnAssembly =
                         Types().That().ResideInAssembly(type.Assembly).Should().Exist();
                     var typesInOtherAssemblyAreOtherTypes =
-                        Types().That().DoNotResideInAssembly(type.Assembly).Should().NotBe(type);
+                        Types().That().DoNotResideInAssembly(type.Assembly).Should().NotBe(type).WithoutRequiringPositiveResults();
 
                     Assert.True(typeResidesInOwnAssembly.HasNoViolations(Architecture));
                     Assert.False(typeDoesNotResideInOwnAssembly.HasNoViolations(Architecture));
@@ -428,7 +429,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
                 var typesInAssemblyAreInAssembly =
                     Types().That().ResideInAssembly(assembly).Should().ResideInAssembly(assembly);
                 var typesInOtherAssemblyAreInOtherAssembly = Types().That().DoNotResideInAssembly(assembly).Should()
-                    .NotResideInAssembly(assembly);
+                    .NotResideInAssembly(assembly).WithoutRequiringPositiveResults();
 
                 Assert.True(typesInAssemblyAreInAssembly.HasNoViolations(Architecture));
                 Assert.True(typesInOtherAssemblyAreInOtherAssembly.HasNoViolations(Architecture));
@@ -439,7 +440,7 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
                 var typesInAssemblyAreInAssembly =
                     Types().That().ResideInAssembly(assembly).Should().ResideInAssembly(assembly);
                 var typesInOtherAssemblyAreInOtherAssembly = Types().That().DoNotResideInAssembly(assembly).Should()
-                    .NotResideInAssembly(assembly);
+                    .NotResideInAssembly(assembly).WithoutRequiringPositiveResults();
 
                 Assert.True(typesInAssemblyAreInAssembly.HasNoViolations(Architecture));
                 Assert.True(typesInOtherAssemblyAreInOtherAssembly.HasNoViolations(Architecture));

--- a/ExampleTest/ExampleArchUnitTest.cs
+++ b/ExampleTest/ExampleArchUnitTest.cs
@@ -45,7 +45,7 @@ namespace ExampleTest
 
 
         //write some tests
-        [Fact]
+        [Fact(Skip = "This is just a syntax example, it does not actually work")]
         public void TypesShouldBeInCorrectLayer()
         {
             //you can use the fluent API to write your own rules
@@ -64,7 +64,7 @@ namespace ExampleTest
             combinedArchRule.Check(Architecture);
         }
 
-        [Fact]
+        [Fact(Skip = "This is just a syntax example, it does not actually work")]
         public void ExampleLayerShouldNotAccessForbiddenLayer()
         {
             //you can give your rules a custom reason, which is displayed when it fails (together with the types that failed the rule)
@@ -73,7 +73,7 @@ namespace ExampleTest
             exampleLayerShouldNotAccessForbiddenLayer.Check(Architecture);
         }
 
-        [Fact]
+        [Fact(Skip = "This is just a syntax example, it does not actually work")]
         public void TypoLayerShouldViolateByDefault()
         {
             // test the new default case
@@ -99,14 +99,14 @@ namespace ExampleTest
             Assert.True(typoLayerCanCauseNoViolations.HasNoViolations(Architecture));
         }
 
-        [Fact]
+        [Fact(Skip = "This is just a syntax example, it does not actually work")]
         public void ForbiddenClassesShouldHaveCorrectName()
         {
             Classes().That().AreAssignableTo(ForbiddenInterfaces).Should().HaveNameContaining("forbidden")
                 .Check(Architecture);
         }
 
-        [Fact]
+        [Fact(Skip = "This is just a syntax example, it does not actually work")]
         public void ExampleClassesShouldNotCallForbiddenMethods()
         {
             Classes().That().Are(ExampleClasses).Should().NotCallAny(


### PR DESCRIPTION
This is a breaking change that requires rules to yield positive results by default. The intent is to protect against misformulated rules.

This is the first public iteration. It still loses type information on WithoutRequiringPositiveResults(), but otherwise I think it's fine.

Resolves #189