### PR TITLE
perf(loader): improve assembly loading

### DIFF
--- a/ArchUnitNET/Loader/ArchBuilder.cs
+++ b/ArchUnitNET/Loader/ArchBuilder.cs
@@ -44,7 +44,7 @@ namespace ArchUnitNET.Loader
             _architectureCache = ArchitectureCache.Instance;
         }
 
-        public IEnumerable<IType> Types => _architectureTypes.Select(pair => pair.Value);
+        public IEnumerable<IType> Types => _architectureTypes.Values;
         public IEnumerable<Assembly> Assemblies => _assemblyRegistry.Assemblies;
         public IEnumerable<Namespace> Namespaces => _namespaceRegistry.Namespaces;
 

--- a/ArchUnitNET/Loader/ArchBuilder.cs
+++ b/ArchUnitNET/Loader/ArchBuilder.cs
@@ -19,7 +19,8 @@ namespace ArchUnitNET.Loader
     {
         private readonly ArchitectureCache _architectureCache;
         private readonly ArchitectureCacheKey _architectureCacheKey;
-        private readonly List<IType> _architectureTypes = new List<IType>();
+        private readonly IDictionary<string, IType> _architectureTypes =
+            new Dictionary<string, IType>();
         private readonly AssemblyRegistry _assemblyRegistry;
         private readonly LoadTaskRegistry _loadTaskRegistry;
         private readonly NamespaceRegistry _namespaceRegistry;
@@ -43,7 +44,7 @@ namespace ArchUnitNET.Loader
             _architectureCache = ArchitectureCache.Instance;
         }
 
-        public IEnumerable<IType> Types => _architectureTypes;
+        public IEnumerable<IType> Types => _architectureTypes.Select(pair => pair.Value);
         public IEnumerable<Assembly> Assemblies => _assemblyRegistry.Assemblies;
         public IEnumerable<Namespace> Namespaces => _namespaceRegistry.Namespaces;
 
@@ -83,6 +84,7 @@ namespace ArchUnitNET.Loader
                     t.FullName != "Microsoft.CodeAnalysis.EmbeddedAttribute"
                     && t.FullName != "System.Runtime.CompilerServices.NullableAttribute"
                     && t.FullName != "System.Runtime.CompilerServices.NullableContextAttribute"
+                    && !t.FullName.StartsWith("Coverlet")
                 )
                 .ToList();
 
@@ -109,10 +111,10 @@ namespace ArchUnitNET.Loader
                 .ForEach(typeDefinition =>
                 {
                     var type = _typeFactory.GetOrCreateTypeFromTypeReference(typeDefinition);
-                    if (!_architectureTypes.Contains(type) && !type.IsCompilerGenerated)
+                    if (!_architectureTypes.ContainsKey(type.FullName) && !type.IsCompilerGenerated)
                     {
                         currentTypes.Add(type);
-                        _architectureTypes.Add(type);
+                        _architectureTypes.Add(type.FullName, type);
                     }
                 });
 

--- a/ArchUnitNET/Loader/MonoCecilMemberExtensions.cs
+++ b/ArchUnitNET/Loader/MonoCecilMemberExtensions.cs
@@ -312,15 +312,18 @@ namespace ArchUnitNET.Loader
 
         internal static bool IsCompilerGenerated(this MemberReference memberReference)
         {
+            if (memberReference.Name.HasCompilerGeneratedName())
+            {
+                return true;
+            }
             var declaringType =
                 memberReference.Resolve()?.DeclaringType ?? memberReference.DeclaringType;
-            return declaringType != null && declaringType.Name.HasCompilerGeneratedName()
-                || memberReference.Name.HasCompilerGeneratedName();
+            return declaringType != null && declaringType.Name.HasCompilerGeneratedName();
         }
 
         internal static bool HasCompilerGeneratedName(this string name)
         {
-            return name.StartsWith("<") || name.StartsWith("!");
+            return name[0] == '<' || name[0] == '!';
         }
 
         internal static MethodForm GetMethodForm(this MethodDefinition methodDefinition)


### PR DESCRIPTION
- In `ArchUnitNET/Loader/ArchBuilder.cs` we use a `Dictionary` instead of a `List` for a more efficient lookup. In my tests this improves loding times for lange numbers of assembiles and halfes the execution time for the `LoadAssembliesIncludingRecursiveDependencies` test.
- Small performance improvement in `ArchUnitNET/Loader/MonoCecilMemberExtensions.cs` by performing checks more efficiently.