### PR TITLE
added Fluent Syntax for classes that are records

### DIFF
--- a/ArchUnitNET/Domain/Class.cs
+++ b/ArchUnitNET/Domain/Class.cs
@@ -16,11 +16,12 @@ namespace ArchUnitNET.Domain
     {
         private IType Type { get; }
 
-        public Class(IType type, bool? isAbstract = null, bool? isSealed = null)
+        public Class(IType type, bool? isAbstract = null, bool? isSealed = null, bool? isRecord = null)
         {
             Type = type;
             IsAbstract = isAbstract;
             IsSealed = isSealed;
+            IsRecord = isRecord;
         }
 
         public Class(Class @class)
@@ -28,6 +29,7 @@ namespace ArchUnitNET.Domain
             Type = @class.Type;
             IsAbstract = @class.IsAbstract;
             IsSealed = @class.IsSealed;
+            IsRecord = @class.IsRecord;
         }
 
         public IEnumerable<ITypeDependency> DependenciesIncludingInherited =>
@@ -47,6 +49,7 @@ namespace ArchUnitNET.Domain
         public IEnumerable<MethodMember> Constructors => Type.GetConstructors();
         public bool? IsAbstract { get; }
         public bool? IsSealed { get; }
+        public bool? IsRecord { get; }
 
         public IEnumerable<Class> InheritedClasses =>
             BaseClass == null
@@ -86,7 +89,8 @@ namespace ArchUnitNET.Domain
         {
             return Equals(Type, other.Type)
                 && Equals(IsAbstract, other.IsAbstract)
-                && Equals(IsSealed, other.IsSealed);
+                && Equals(IsSealed, other.IsSealed)
+                && Equals(IsRecord, other.IsRecord);
         }
 
         public override bool Equals(object obj)
@@ -111,6 +115,7 @@ namespace ArchUnitNET.Domain
                 var hashCode = Type != null ? Type.GetHashCode() : 0;
                 hashCode = (hashCode * 397) ^ IsAbstract.GetHashCode();
                 hashCode = (hashCode * 397) ^ IsSealed.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsRecord.GetHashCode();
                 return hashCode;
             }
         }

--- a/ArchUnitNET/Domain/Class.cs
+++ b/ArchUnitNET/Domain/Class.cs
@@ -16,7 +16,12 @@ namespace ArchUnitNET.Domain
     {
         private IType Type { get; }
 
-        public Class(IType type, bool? isAbstract = null, bool? isSealed = null, bool? isRecord = null)
+        public Class(
+            IType type,
+            bool? isAbstract = null,
+            bool? isSealed = null,
+            bool? isRecord = null
+        )
         {
             Type = type;
             IsAbstract = isAbstract;

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/ClassConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/ClassConditionsDefinition.cs
@@ -30,6 +30,15 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types.Classes
             );
         }
 
+        public static ICondition<Class> BeRecord()
+        {
+            return new SimpleCondition<Class>(
+                cls => !cls.IsRecord.HasValue || cls.IsRecord.Value,
+                "be record",
+                "is not record"
+            );
+        }
+
         public static ICondition<Class> BeImmutable()
         {
             return new SimpleCondition<Class>(
@@ -59,6 +68,14 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types.Classes
                 cls => !cls.IsSealed.HasValue || !cls.IsSealed.Value,
                 "not be sealed",
                 "is sealed"
+            );
+        }
+        public static ICondition<Class> NotBeRecord()
+        {
+            return new SimpleCondition<Class>(
+                cls => !cls.IsRecord.HasValue || !cls.IsRecord.Value,
+                "not be record",
+                "is record"
             );
         }
 

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/ClassConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/ClassConditionsDefinition.cs
@@ -70,6 +70,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types.Classes
                 "is sealed"
             );
         }
+
         public static ICondition<Class> NotBeRecord()
         {
             return new SimpleCondition<Class>(

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/ClassPredicatesDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/ClassPredicatesDefinition.cs
@@ -28,6 +28,14 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types.Classes
             );
         }
 
+        public static IPredicate<Class> AreRecord()
+        {
+            return new SimplePredicate<Class>(
+                cls => !cls.IsRecord.HasValue || cls.IsRecord.Value,
+                "are record"
+            );
+        }
+
         public static IPredicate<Class> AreImmutable()
         {
             return new SimplePredicate<Class>(
@@ -53,6 +61,14 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types.Classes
             return new SimplePredicate<Class>(
                 cls => !cls.IsSealed.HasValue || !cls.IsSealed.Value,
                 "are not sealed"
+            );
+        }
+
+        public static IPredicate<Class> AreNotRecord()
+        {
+            return new SimplePredicate<Class>(
+                cls => !cls.IsRecord.HasValue || !cls.IsRecord.Value,
+                "are not record"
             );
         }
 

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/ClassesShould.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/ClassesShould.cs
@@ -27,6 +27,12 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types.Classes
             return new ClassesShouldConjunction(_ruleCreator);
         }
 
+        public ClassesShouldConjunction BeRecord()
+        {
+            _ruleCreator.AddCondition(ClassConditionsDefinition.BeRecord());
+            return new ClassesShouldConjunction(_ruleCreator);
+        }
+
         public ClassesShouldConjunction BeImmutable()
         {
             _ruleCreator.AddCondition(ClassConditionsDefinition.BeImmutable());
@@ -45,6 +51,12 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types.Classes
         public ClassesShouldConjunction NotBeSealed()
         {
             _ruleCreator.AddCondition(ClassConditionsDefinition.NotBeSealed());
+            return new ClassesShouldConjunction(_ruleCreator);
+        }
+
+        public ClassesShouldConjunction NotBeRecord()
+        {
+            _ruleCreator.AddCondition(ClassConditionsDefinition.NotBeRecord());
             return new ClassesShouldConjunction(_ruleCreator);
         }
 

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/GivenClassesThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/GivenClassesThat.cs
@@ -27,6 +27,12 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types.Classes
             return new GivenClassesConjunction(_ruleCreator);
         }
 
+        public GivenClassesConjunction AreRecord()
+        {
+            _ruleCreator.AddPredicate(ClassPredicatesDefinition.AreRecord());
+            return new GivenClassesConjunction(_ruleCreator);
+        }
+
         public GivenClassesConjunction AreImmutable()
         {
             _ruleCreator.AddPredicate(ClassPredicatesDefinition.AreImmutable());
@@ -45,6 +51,12 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types.Classes
         public GivenClassesConjunction AreNotSealed()
         {
             _ruleCreator.AddPredicate(ClassPredicatesDefinition.AreNotSealed());
+            return new GivenClassesConjunction(_ruleCreator);
+        }
+
+        public GivenClassesConjunction AreNotRecord()
+        {
+            _ruleCreator.AddPredicate(ClassPredicatesDefinition.AreNotRecord());
             return new GivenClassesConjunction(_ruleCreator);
         }
 

--- a/ArchUnitNET/Loader/MonoCecilTypeExtensions.cs
+++ b/ArchUnitNET/Loader/MonoCecilTypeExtensions.cs
@@ -18,6 +18,8 @@ namespace ArchUnitNET.Loader
 {
     internal static class MonoCecilTypeExtensions
     {
+        private const string RecordCloneMethodName = "<Clone>$";
+
         internal static string BuildFullName(this TypeReference typeReference)
         {
             if (typeReference.IsGenericParameter)
@@ -107,7 +109,7 @@ namespace ArchUnitNET.Loader
 
         internal static bool IsRecord(this TypeDefinition typeDefinition)
         {
-            return typeDefinition.IsClass && typeDefinition.GetMethods().Any(x => x.Name == "<Clone>$");
+            return typeDefinition.IsClass && typeDefinition.GetMethods().Any(x => x.Name == RecordCloneMethodName);
         }
     }
 }

--- a/ArchUnitNET/Loader/MonoCecilTypeExtensions.cs
+++ b/ArchUnitNET/Loader/MonoCecilTypeExtensions.cs
@@ -109,7 +109,8 @@ namespace ArchUnitNET.Loader
 
         internal static bool IsRecord(this TypeDefinition typeDefinition)
         {
-            return typeDefinition.IsClass && typeDefinition.GetMethods().Any(x => x.Name == RecordCloneMethodName);
+            return typeDefinition.IsClass
+                && typeDefinition.GetMethods().Any(x => x.Name == RecordCloneMethodName);
         }
     }
 }

--- a/ArchUnitNET/Loader/MonoCecilTypeExtensions.cs
+++ b/ArchUnitNET/Loader/MonoCecilTypeExtensions.cs
@@ -6,9 +6,11 @@
 //
 
 using System;
+using System.Linq;
 using ArchUnitNET.Domain;
 using JetBrains.Annotations;
 using Mono.Cecil;
+using Mono.Cecil.Rocks;
 using static ArchUnitNET.Domain.Visibility;
 using GenericParameter = Mono.Cecil.GenericParameter;
 
@@ -101,6 +103,11 @@ namespace ArchUnitNET.Loader
             throw new ArgumentException(
                 "The provided type definition seems to have no visibility."
             );
+        }
+
+        internal static bool IsRecord(this TypeDefinition typeDefinition)
+        {
+            return typeDefinition.IsClass && typeDefinition.GetMethods().Any(x => x.Name == "<Clone>$");
         }
     }
 }

--- a/ArchUnitNET/Loader/TypeFactory.cs
+++ b/ArchUnitNET/Loader/TypeFactory.cs
@@ -353,7 +353,7 @@ namespace ArchUnitNET.Loader
             else
             {
                 createdTypeInstance = new TypeInstance<Class>(
-                    new Class(type, typeDefinition.IsAbstract, typeDefinition.IsSealed)
+                    new Class(type, typeDefinition.IsAbstract, typeDefinition.IsSealed, typeDefinition.IsRecord())
                 );
             }
 

--- a/ArchUnitNET/Loader/TypeFactory.cs
+++ b/ArchUnitNET/Loader/TypeFactory.cs
@@ -353,7 +353,12 @@ namespace ArchUnitNET.Loader
             else
             {
                 createdTypeInstance = new TypeInstance<Class>(
-                    new Class(type, typeDefinition.IsAbstract, typeDefinition.IsSealed, typeDefinition.IsRecord())
+                    new Class(
+                        type,
+                        typeDefinition.IsAbstract,
+                        typeDefinition.IsSealed,
+                        typeDefinition.IsRecord()
+                    )
                 );
             }
 

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/ClassSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/ClassSyntaxElementsTests.cs
@@ -233,29 +233,13 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
         [Fact]
         public void AreRecordTest()
         {
-            var recordsAreRecord = Classes()
-                .That()
-                .AreRecord()
-                .Should()
-                .BeRecord();
+            var recordsAreRecord = Classes().That().AreRecord().Should().BeRecord();
 
-            var recordsAreNotRecord = Classes()
-                .That()
-                .AreRecord()
-                .Should()
-                .NotBeRecord();
+            var recordsAreNotRecord = Classes().That().AreRecord().Should().NotBeRecord();
 
-            var notRecordsAreRecord = Classes()
-                .That()
-                .AreNotRecord()
-                .Should()
-                .BeRecord();
+            var notRecordsAreRecord = Classes().That().AreNotRecord().Should().BeRecord();
 
-            var notRecordsAreNotRecord = Classes()
-                .That()
-                .AreNotRecord()
-                .Should()
-                .NotBeRecord();
+            var notRecordsAreNotRecord = Classes().That().AreNotRecord().Should().NotBeRecord();
 
             Assert.True(recordsAreRecord.HasNoViolations(Architecture));
             Assert.False(recordsAreNotRecord.HasNoViolations(Architecture));

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/ClassSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/ClassSyntaxElementsTests.cs
@@ -230,6 +230,39 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
             Assert.True(notImmutableClassesAreNotImmutabled.HasNoViolations(Architecture));
         }
 
+        [Fact]
+        public void AreRecordTest()
+        {
+            var recordsAreRecord = Classes()
+                .That()
+                .AreRecord()
+                .Should()
+                .BeRecord();
+
+            var recordsAreNotRecord = Classes()
+                .That()
+                .AreRecord()
+                .Should()
+                .NotBeRecord();
+
+            var notRecordsAreRecord = Classes()
+                .That()
+                .AreNotRecord()
+                .Should()
+                .BeRecord();
+
+            var notRecordsAreNotRecord = Classes()
+                .That()
+                .AreNotRecord()
+                .Should()
+                .NotBeRecord();
+
+            Assert.True(recordsAreRecord.HasNoViolations(Architecture));
+            Assert.False(recordsAreNotRecord.HasNoViolations(Architecture));
+            Assert.False(notRecordsAreRecord.HasNoViolations(Architecture));
+            Assert.True(notRecordsAreNotRecord.HasNoViolations(Architecture));
+        }
+
         private record ImmutableRecord(string Property, string AnotherProperty);
 
         private class ImmutableClass


### PR DESCRIPTION
Identifies if a class is a record if it has a methode named "<Clone>$"

inspired from this post: [stackoverflow](https://stackoverflow.com/questions/64809750/how-to-check-if-type-is-a-record)