### PR TITLE
Issue: #269 Least effort implementation of a clearable Architecture cache

### DIFF
--- a/ArchUnitNET/Domain/ArchitectureCache.cs
+++ b/ArchUnitNET/Domain/ArchitectureCache.cs
@@ -28,5 +28,7 @@ namespace ArchUnitNET.Domain
         {
             return Cache.TryAdd(architectureCacheKey, architecture);
         }
+
+        public void Clear() => Cache.Clear();
     }
 }

--- a/ArchUnitNETTests/Domain/ArchitectureCacheTests.cs
+++ b/ArchUnitNETTests/Domain/ArchitectureCacheTests.cs
@@ -50,5 +50,17 @@ namespace ArchUnitNETTests.Domain
                 _testEmptyArchitecture
             );
         }
+
+        [Fact]
+        public void CacheClear()
+        {
+            _testArchitectureCache.Add(_testArchitectureCacheKey, _testEmptyArchitecture);
+            Assert.Equal(
+                _testArchitectureCache.TryGetArchitecture(_testArchitectureCacheKey),
+                _testEmptyArchitecture
+            );
+            _testArchitectureCache.Clear();
+            Assert.Null(_testArchitectureCache.TryGetArchitecture(_testArchitectureCacheKey));
+        }
     }
 }

--- a/ArchUnitNETTests/Domain/TestArchitectureCache.cs
+++ b/ArchUnitNETTests/Domain/TestArchitectureCache.cs
@@ -14,10 +14,5 @@ namespace ArchUnitNETTests.Domain
         {
             return Cache.Count;
         }
-
-        public void Clear()
-        {
-            Cache.Clear();
-        }
     }
 }


### PR DESCRIPTION
This is a least effort implementation of a clearable Architecture cache. This will allow calls to `ArchitectureCache.Instance.Clear()` from external sources in scenarios where a uniqueness of the `ArchitectureCacheKey` during the runtime of the consuming app cannot be guaranteed and thus, the `Cache` needs to be cleared between executions of the `ArchBuilder` resp. `ArchLoader´.