### PR TITLE
Adds a helper method to simplify the verification of dependencies

### DIFF
--- a/ArchUnitNET/Fluent/Dependencies.cs
+++ b/ArchUnitNET/Fluent/Dependencies.cs
@@ -3,6 +3,7 @@
 // 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
 // 
 // 	SPDX-License-Identifier: Apache-2.0
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -20,7 +21,8 @@ namespace ArchUnitNET.Fluent
         public static IArchRule Check(Assembly source, IEnumerable<Assembly> target)
         {
             var allowedTypes = Types().That().ResideInAssembly(source);
-            allowedTypes = target.Aggregate(allowedTypes, (current, assembly) => current.Or().ResideInAssembly(assembly));
+            allowedTypes =
+                target.Aggregate(allowedTypes, (current, assembly) => current.Or().ResideInAssembly(assembly));
 
             var rule = Types()
                 .That()

--- a/ArchUnitNET/Fluent/Dependencies.cs
+++ b/ArchUnitNET/Fluent/Dependencies.cs
@@ -1,0 +1,34 @@
+// Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+// 
+// 	SPDX-License-Identifier: Apache-2.0
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+namespace ArchUnitNET.Fluent
+{
+    public static class Dependencies
+    {
+        /// <summary>
+        /// Verifies that a source assembly only depends on a set of target assemblies.
+        /// </summary>
+        /// <param name="source">The source assembly</param>
+        /// <param name="target">The assemblies which are allowed to be used from the source assembly</param>
+        public static IArchRule Check(Assembly source, IEnumerable<Assembly> target)
+        {
+            var allowedTypes = Types().That().ResideInAssembly(source);
+            allowedTypes = target.Aggregate(allowedTypes, (current, assembly) => current.Or().ResideInAssembly(assembly));
+
+            var rule = Types()
+                .That()
+                .ResideInAssembly(source)
+                .Should()
+                .OnlyDependOn(allowedTypes);
+
+            return rule;
+        }
+    }
+}


### PR DESCRIPTION
I created a method that really simpilifies the verification of dependencies at the assembly level. You just need to write `var rule = Dependencies.Check(sourceAssembly, [targetAssembly1, targetAssembly2])`, call `rule.Check` and you're done.

It would be awesome if this method would be integrated into ArchUnitNET.