### PR TITLE
ci: improve test coverage and add snapshot tests for object conditions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -4,7 +4,24 @@
   "tools": {
     "csharpier": {
       "version": "0.28.2",
-      "commands": ["dotnet-csharpier"]
+      "commands": [
+        "dotnet-csharpier"
+      ],
+      "rollForward": false
+    },
+    "verify.tool": {
+      "version": "0.6.0",
+      "commands": [
+        "dotnet-verify"
+      ],
+      "rollForward": false
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.3.8",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/ArchUnit.sln
+++ b/ArchUnit.sln
@@ -20,6 +20,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchUnitNET.MSTestV2", "Arc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchUnitNET.MSTestV2Tests", "ArchUnitNET.MSTestV2Tests\ArchUnitNET.MSTestV2Tests.csproj", "{6D6B6EFE-DA0B-4C4D-B710-FA658F0C68CF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestAssemblies", "TestAssemblies", "{B1191F18-91CB-4387-B775-A5EB64D3AC30}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyAssembly", "TestAssemblies\DependencyAssembly\DependencyAssembly.csproj", "{10A70A38-A18D-4FA8-AF25-2B25B3D60BE6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeAssembly", "TestAssemblies\AttributeAssembly\AttributeAssembly.csproj", "{FB457140-47B4-4B20-8505-BA9BFC73C705}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisibilityAssembly", "TestAssemblies\VisibilityAssembly\VisibilityAssembly.csproj", "{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,8 +70,25 @@ Global
 		{6D6B6EFE-DA0B-4C4D-B710-FA658F0C68CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6D6B6EFE-DA0B-4C4D-B710-FA658F0C68CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6D6B6EFE-DA0B-4C4D-B710-FA658F0C68CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10A70A38-A18D-4FA8-AF25-2B25B3D60BE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10A70A38-A18D-4FA8-AF25-2B25B3D60BE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10A70A38-A18D-4FA8-AF25-2B25B3D60BE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10A70A38-A18D-4FA8-AF25-2B25B3D60BE6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB457140-47B4-4B20-8505-BA9BFC73C705}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB457140-47B4-4B20-8505-BA9BFC73C705}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB457140-47B4-4B20-8505-BA9BFC73C705}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB457140-47B4-4B20-8505-BA9BFC73C705}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{10A70A38-A18D-4FA8-AF25-2B25B3D60BE6} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
+		{FB457140-47B4-4B20-8505-BA9BFC73C705} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
+		{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 	EndGlobalSection
 EndGlobal

--- a/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs
@@ -374,12 +374,11 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
         )
         {
             var patternList = patterns.ToList();
-
-            bool Condition(TRuleType ruleType)
+            bool Condition(TRuleType ruleType, Architecture architecture)
             {
-                return !ruleType.GetTypeDependencies().IsNullOrEmpty()
+                return !ruleType.GetTypeDependencies(architecture).IsNullOrEmpty()
                     && ruleType
-                        .GetTypeDependencies()
+                        .GetTypeDependencies(architecture)
                         .Any(target =>
                             patternList.Any(pattern =>
                                 target.FullNameMatches(pattern, useRegularExpressions)
@@ -421,7 +420,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                     );
             }
 
-            return new SimpleCondition<TRuleType>(Condition, description, failDescription);
+            return new ArchitectureCondition<TRuleType>(Condition, description, failDescription);
         }
 
         public static ICondition<TRuleType> DependOnAny(IType firstType, params IType[] moreTypes)
@@ -1943,7 +1942,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                                 goto NextAttribute;
                             }
                         }
-                        else if (!argumentList.Contains(arg))
+                        else if (!attributeArgs.Contains(arg))
                         {
                             goto NextAttribute;
                         }
@@ -2034,7 +2033,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                                 goto NextAttribute;
                             }
                         }
-                        else if (!argumentList.Contains(arg))
+                        else if (!attributeArgs.Contains(arg))
                         {
                             goto NextAttribute;
                         }
@@ -2136,7 +2135,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                                 goto NextAttribute;
                             }
                         }
-                        else if (!argumentList.Contains(arg))
+                        else if (!attributeArgs.Contains(arg))
                         {
                             goto NextAttribute;
                         }
@@ -3742,7 +3741,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                                 goto NextAttribute;
                             }
                         }
-                        else if (!argumentList.Contains(arg))
+                        else if (!attributeArgs.Contains(arg))
                         {
                             goto NextAttribute;
                         }
@@ -3833,7 +3832,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                                 goto NextAttribute;
                             }
                         }
-                        else if (!argumentList.Contains(arg))
+                        else if (!attributeArgs.Contains(arg))
                         {
                             goto NextAttribute;
                         }
@@ -3935,7 +3934,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements
                                 goto NextAttribute;
                             }
                         }
-                        else if (!argumentList.Contains(arg))
+                        else if (!attributeArgs.Contains(arg))
                         {
                             goto NextAttribute;
                         }

--- a/ArchUnitNETTests/ArchUnitNETTests.csproj
+++ b/ArchUnitNETTests/ArchUnitNETTests.csproj
@@ -10,6 +10,9 @@
   <ItemGroup>
     <ProjectReference Include="..\ArchUnitNET.xUnit\ArchUnitNET.xUnit.csproj" />
     <ProjectReference Include="..\TestAssembly\TestAssembly.csproj" />
+    <ProjectReference Include="..\TestAssemblies\AttributeAssembly\AttributeAssembly.csproj" />
+    <ProjectReference Include="..\TestAssemblies\DependencyAssembly\DependencyAssembly.csproj" />
+    <ProjectReference Include="..\TestAssemblies\VisibilityAssembly\VisibilityAssembly.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,7 +21,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="Verify.xunit" Version="26.1.6" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 

--- a/ArchUnitNETTests/AssemblyTestHelper/AssemblyTestHelper.cs
+++ b/ArchUnitNETTests/AssemblyTestHelper/AssemblyTestHelper.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Fluent.Extensions;
+using VerifyXunit;
+using Xunit;
+
+namespace ArchUnitNETTests.AssemblyTestHelper;
+
+public abstract class AssemblyTestHelper
+{
+    private StringBuilder snapshot = new StringBuilder();
+
+    public readonly string NonExistentObjectName = "NotTheNameOfAnyObject";
+
+    public abstract Architecture Architecture { get; }
+
+    public void AddSnapshotHeader(string header)
+    {
+        snapshot.AppendLine("===== " + header + " =====\n");
+    }
+
+    private string FormatSnapshot(IArchRule rule, IEnumerable<EvaluationResult> results)
+    {
+        var formatted = new StringBuilder();
+        formatted.Append("Query: ");
+        formatted.AppendLine(rule.Description);
+        foreach (var result in results)
+        {
+            formatted.Append("Result: ");
+            formatted.AppendLine(result.Passed.ToString());
+            formatted.Append("Description: ");
+            formatted.AppendLine(result.ToString());
+        }
+        formatted.AppendLine("Message: ");
+        formatted.AppendLine(results.ToErrorMessage());
+        formatted.AppendLine();
+        return formatted.ToString();
+    }
+
+    public void AssertNoViolations(IArchRule rule)
+    {
+        var results = rule.Evaluate(Architecture);
+        var output = FormatSnapshot(rule, results);
+        if (!results.All(result => result.Passed))
+        {
+            Assert.Fail(output);
+        }
+        snapshot.Append(output);
+    }
+
+    public void AssertAnyViolations(IArchRule rule)
+    {
+        var results = rule.Evaluate(Architecture);
+        var output = FormatSnapshot(rule, results);
+        if (results.All(result => !result.Passed))
+        {
+            Assert.Fail("AssertOnlyViolations should be used for tests without passing results.");
+        }
+        if (results.All(result => result.Passed))
+        {
+            Assert.Fail(output);
+        }
+        snapshot.Append(output);
+    }
+
+    public void AssertOnlyViolations(IArchRule rule)
+    {
+        var results = rule.Evaluate(Architecture);
+        var output = FormatSnapshot(rule, results);
+        if (results.Any(result => result.Passed))
+        {
+            Assert.Fail(output);
+        }
+        snapshot.Append(output);
+    }
+
+    public Task AssertSnapshotMatches([CallerFilePath] string sourceFile = "")
+    {
+        return Verifier
+            .Verify(snapshot.ToString(), null, sourceFile)
+            .DisableDiff() // Don't open diff tool during the test
+            .UseDirectory("Snapshots");
+    }
+}

--- a/ArchUnitNETTests/AssemblyTestHelper/AssemblyTestHelperExtensions.cs
+++ b/ArchUnitNETTests/AssemblyTestHelper/AssemblyTestHelperExtensions.cs
@@ -1,0 +1,23 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using ArchUnitNET.Fluent;
+
+namespace ArchUnitNETTests.AssemblyTestHelper;
+
+public static class AssemblyTestHelperExtensions
+{
+    public static void AssertNoViolations(this IArchRule archRule, AssemblyTestHelper testHelper)
+    {
+        testHelper.AssertNoViolations(archRule);
+    }
+
+    public static void AssertAnyViolations(this IArchRule archRule, AssemblyTestHelper testHelper)
+    {
+        testHelper.AssertAnyViolations(archRule);
+    }
+
+    public static void AssertOnlyViolations(this IArchRule archRule, AssemblyTestHelper testHelper)
+    {
+        testHelper.AssertOnlyViolations(archRule);
+    }
+}

--- a/ArchUnitNETTests/AssemblyTestHelper/AttributeAssemblyTestHelper.cs
+++ b/ArchUnitNETTests/AssemblyTestHelper/AttributeAssemblyTestHelper.cs
@@ -1,0 +1,127 @@
+using System.Linq;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Domain.Extensions;
+using AttributeNamespace;
+
+namespace ArchUnitNETTests.AssemblyTestHelper;
+
+public class AttributeAssemblyTestHelpers : AssemblyTestHelper
+{
+    public override Architecture Architecture
+    {
+        get => StaticTestArchitectures.AttributeArchitecture;
+    }
+
+    public string NonExistentAttributeValue = "NotTheValueOfAnyAttribute";
+
+    public object Attribute1Parameter1Value = "Argument";
+    public object Attribute1Parameter2Value = 0;
+    public object Attribute1Parameter3Value = typeof(TypeArgument);
+    public object Attribute1Parameter3InvalidValue = typeof(OtherTypeArgument);
+
+    public string Attribute1NamedParameter1Name = "NamedParameter1";
+    public object Attribute1NamedParameter1Value = typeof(NamedTypeArgument);
+    public (string, object) Attribute1NamedParameter1Pair = (
+        "NamedParameter1",
+        typeof(NamedTypeArgument)
+    );
+    public (string, object) Attribute1NamedParameter1InvalidNamePair = (
+        "OtherNamedParameter1",
+        typeof(NamedTypeArgument)
+    );
+    public (string, object) Attribute1NamedParameter1InvalidValuePair = (
+        "NamedParameter1",
+        typeof(OtherNamedTypeArgument)
+    );
+    public string Attribute1NamedParameter2Name = "NamedParameter2";
+    public object Attribute1NamedParameter2Value = "NamedArgument";
+    public (string, object) Attribute1NamedParameter2Pair = ("NamedParameter2", "NamedArgument");
+    public (string, object) Attribute1NamedParameter2InvalidNamePair = (
+        "OtherNamedParameter2",
+        "NamedArgument"
+    );
+    public (string, object) Attribute1NamedParameter2InvalidValuePair = (
+        "NamedParameter2",
+        "OtherNamedArgument"
+    );
+    public string Attribute1NamedParameter3Name = "NamedParameter3";
+    public object Attribute1NamedParameter3Value = 1;
+    public (string, object) Attribute1NamedParameter3Pair = ("NamedParameter3", 1);
+
+    public object Attribute2Parameter1Value = typeof(OtherTypeArgument);
+    public object Attribute2Parameter2Value = "OtherArgument";
+    public object Attribute2Parameter3Value = 2;
+
+    public string Attribute2NamedParameter1Name = "OtherNamedParameter1";
+    public object Attribute2NamedParameter1Value = "OtherNamedArgument";
+    public (string, object) Attribute2NamedParameter1Pair = (
+        "OtherNamedParameter1",
+        "OtherNamedArgument"
+    );
+    public string Attribute2NamedParameter2Name = "OtherNamedParameter2";
+    public object Attribute2NamedParameter2Value = 3;
+    public (string, object) Attribute2NamedParameter2Pair = ("OtherNamedParameter2", 3);
+    public string Attribute2NamedParameter3Name = "OtherNamedParameter3";
+    public object Attribute2NamedParameter3Value = typeof(OtherNamedTypeArgument);
+    public (string, object) Attribute2NamedParameter3Pair = (
+        "OtherNamedParameter3",
+        typeof(OtherNamedTypeArgument)
+    );
+
+    public string UnusedParameterName = "UnusedParameter";
+    public object UnusedParameterValue = "UnusedValueArgument";
+    public object UnusedTypeParameterValue = typeof(UnusedTypeArgument);
+
+    public Attribute Attribute1;
+    public System.Type Attribute1SystemType = typeof(Attribute1);
+
+    public Attribute Attribute2;
+    public System.Type Attribute2SystemType = typeof(Attribute2);
+
+    public Attribute UnusedAttribute;
+    public System.Type UnusedAttributeSystemType = typeof(UnusedAttribute);
+
+    public Class ClassWithoutAttributes;
+    public System.Type ClassWithoutAttributesSystemType = typeof(ClassWithoutAttributes);
+
+    public Class OtherClassWithoutAttributes;
+    public System.Type OtherClassWithoutAttributesSystemType = typeof(OtherClassWithoutAttributes);
+
+    public Class ClassWithSingleAttribute;
+    public System.Type ClassWithSingleAttributeSystemType = typeof(ClassWithSingleAttribute);
+
+    public Class OtherClassWithSingleAttribute;
+    public System.Type OtherClassWithSingleAttributeSystemType =
+        typeof(OtherClassWithSingleAttribute);
+
+    public Class ClassWithAttributes;
+    public System.Type ClassWithAttributesSystemType = typeof(ClassWithAttributes);
+
+    public Class OtherClassWithAttributes;
+    public System.Type OtherClassWithAttributesSystemType = typeof(OtherClassWithAttributes);
+
+    public Class ClassWithArguments;
+    public System.Type ClassWithArgumentsSystemType = typeof(ClassWithArguments);
+
+    public Class OtherClassWithArguments;
+    public System.Type OtherClassWithArgumentsSystemType = typeof(OtherClassWithArguments);
+
+    public AttributeAssemblyTestHelpers()
+    {
+        Attribute1 = Architecture.GetAttributeOfType(typeof(Attribute1));
+        Attribute2 = Architecture.GetAttributeOfType(typeof(Attribute2));
+        UnusedAttribute = Architecture.GetAttributeOfType(typeof(UnusedAttribute));
+        ClassWithoutAttributes = Architecture.GetClassOfType(typeof(ClassWithoutAttributes));
+        OtherClassWithoutAttributes = Architecture.GetClassOfType(
+            typeof(OtherClassWithoutAttributes)
+        );
+        ClassWithSingleAttribute = Architecture.GetClassOfType(typeof(ClassWithSingleAttribute));
+        OtherClassWithSingleAttribute = Architecture.GetClassOfType(
+            typeof(OtherClassWithSingleAttribute)
+        );
+        ClassWithAttributes = Architecture.GetClassOfType(typeof(ClassWithAttributes));
+        OtherClassWithAttributes = Architecture.GetClassOfType(typeof(OtherClassWithAttributes));
+        ClassWithArguments = Architecture.GetClassOfType(typeof(ClassWithArguments));
+        OtherClassWithArguments = Architecture.GetClassOfType(typeof(OtherClassWithArguments));
+    }
+}

--- a/ArchUnitNETTests/AssemblyTestHelper/DependencyAssemblyTestHelpers.cs
+++ b/ArchUnitNETTests/AssemblyTestHelper/DependencyAssemblyTestHelpers.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Linq;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Domain.Extensions;
+using TypeDependencyNamespace;
+
+namespace ArchUnitNETTests.AssemblyTestHelper;
+
+public class DependencyAssemblyTestHelper : AssemblyTestHelper
+{
+    public override Architecture Architecture
+    {
+        get => StaticTestArchitectures.DependencyArchitecture;
+    }
+
+    public Class BaseClass;
+    public Type BaseClassSystemType = typeof(BaseClass);
+
+    public Class ChildClass;
+    public Type ChildClassSystemType = typeof(ChildClass);
+
+    public Class OtherChildClass;
+    public Type OtherChildClassSystemType = typeof(OtherChildClass);
+
+    public Class BaseClassWithMember;
+    public Type BaseClassWithMemberSystemType = typeof(BaseClassWithMember);
+
+    public Class ChildClassWithMember;
+    public Type ChildClassWithMemberSystemType = typeof(ChildClassWithMember);
+
+    public Class OtherChildClassWithMember;
+    public Type OtherChildClassWithMemberSystemType = typeof(OtherChildClassWithMember);
+
+    public Class BaseClassWithMultipleDependencies;
+    public Type BaseClassWithMultipleDependenciesSystemType =
+        typeof(BaseClassWithMultipleDependencies);
+
+    public Class ChildClass1;
+    public Type ChildClass1SystemType = typeof(ChildClass1);
+
+    public Class ChildClass2;
+    public Type ChildClass2SystemType = typeof(ChildClass2);
+
+    public Class OtherBaseClass;
+    public Type OtherBaseClassSystemType = typeof(OtherBaseClass);
+
+    public Class ClassWithMultipleDependencies;
+    public Type ClassWithMultipleDependenciesSystemType = typeof(ClassWithMultipleDependencies);
+
+    public Class ClassWithoutDependencies;
+    public Type ClassWithoutDependenciesSystemType = typeof(ClassWithoutDependencies);
+
+    public Class OtherClassWithoutDependencies;
+    public Type OtherClassWithoutDependenciesSystemType = typeof(OtherClassWithoutDependencies);
+
+    public MethodMember MethodWithSingleDependency;
+
+    public MethodMember CalledMethod;
+
+    public MethodMember MethodWithMultipleDependencies;
+
+    public MethodMember CalledMethod1;
+
+    public MethodMember CalledMethod2;
+
+    public MethodMember CalledMethod3;
+
+    public MethodMember UnusedMethod;
+
+    public MethodMember MethodWithoutDependencies;
+
+    public DependencyAssemblyTestHelper()
+    {
+        BaseClass = Architecture.GetClassOfType(typeof(BaseClass));
+        ChildClass = Architecture.GetClassOfType(typeof(ChildClass));
+        OtherChildClass = Architecture.GetClassOfType(typeof(OtherChildClass));
+        BaseClassWithMember = Architecture.GetClassOfType(typeof(BaseClassWithMember));
+        ChildClassWithMember = Architecture.GetClassOfType(typeof(ChildClassWithMember));
+        OtherChildClassWithMember = Architecture.GetClassOfType(typeof(OtherChildClassWithMember));
+        BaseClassWithMultipleDependencies = Architecture.GetClassOfType(
+            typeof(BaseClassWithMultipleDependencies)
+        );
+        ChildClass1 = Architecture.GetClassOfType(typeof(ChildClass1));
+        ChildClass2 = Architecture.GetClassOfType(typeof(ChildClass2));
+        OtherBaseClass = Architecture.GetClassOfType(typeof(OtherBaseClass));
+        ClassWithMultipleDependencies = Architecture.GetClassOfType(
+            typeof(ClassWithMultipleDependencies)
+        );
+        ClassWithoutDependencies = Architecture.GetClassOfType(typeof(ClassWithoutDependencies));
+        OtherClassWithoutDependencies = Architecture.GetClassOfType(
+            typeof(OtherClassWithoutDependencies)
+        );
+        MethodWithSingleDependency = Architecture
+            .MethodMembers.WhereNameIs("MethodWithSingleDependency()")
+            .First();
+        CalledMethod = Architecture.MethodMembers.WhereNameIs("CalledMethod()").First();
+        MethodWithMultipleDependencies = Architecture
+            .MethodMembers.WhereNameIs("MethodWithMultipleDependencies()")
+            .First();
+        CalledMethod1 = Architecture.MethodMembers.WhereNameIs("CalledMethod1()").First();
+        CalledMethod2 = Architecture.MethodMembers.WhereNameIs("CalledMethod2()").First();
+        CalledMethod3 = Architecture.MethodMembers.WhereNameIs("CalledMethod3()").First();
+        MethodWithoutDependencies = Architecture
+            .MethodMembers.WhereNameIs("MethodWithoutDependencies()")
+            .First();
+    }
+}

--- a/ArchUnitNETTests/AssemblyTestHelper/VisibilityAssemblyTestHelper.cs
+++ b/ArchUnitNETTests/AssemblyTestHelper/VisibilityAssemblyTestHelper.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Domain.Extensions;
+using VisibilityNamespace;
+using Xunit;
+
+namespace ArchUnitNETTests.AssemblyTestHelper;
+
+public class VisibilityAssemblyTestHelper : AssemblyTestHelper
+{
+    public override Architecture Architecture
+    {
+        get => StaticTestArchitectures.VisibilityArchitecture;
+    }
+
+    public Class PublicClass;
+    public Type PublicSystemType = typeof(PublicClass);
+
+    public Class OtherPublicClass;
+    public Type OtherPublicClassSystemType = typeof(OtherPublicClass);
+
+    public Class InternalClass;
+
+    public Class OtherInternalClass;
+
+    public Class OuterClass;
+    public Type OuterSystemType = typeof(OuterClass);
+
+    public Class PublicInnerClass;
+    public Type PublicInnerSystemType = typeof(OuterClass.PublicInnerClass);
+
+    public Class OtherPublicInnerClass;
+    public Type OtherPublicInnerSystemType = typeof(OuterClass.OtherPublicInnerClass);
+
+    public Class InternalInnerClass;
+
+    public Class OtherInternalInnerClass;
+
+    public Class ProtectedInternalInnerClass;
+
+    public Class OtherProtectedInternalInnerClass;
+
+    public Class ProtectedInnerClass;
+
+    public Class OtherProtectedInnerClass;
+
+    public Class PrivateProtectedInnerClass;
+
+    public Class OtherPrivateProtectedInnerClass;
+
+    public Class PrivateInnerClass;
+
+    public Class OtherPrivateInnerClass;
+
+    public VisibilityAssemblyTestHelper()
+    {
+        PublicClass = Architecture.GetClassOfType(typeof(PublicClass));
+        OtherPublicClass = Architecture.GetClassOfType(typeof(OtherPublicClass));
+        InternalClass = Architecture.Classes.WhereNameIs("InternalClass").First();
+        OtherInternalClass = Architecture.Classes.WhereNameIs("OtherInternalClass").First();
+        OuterClass = Architecture.GetClassOfType(typeof(OuterClass));
+        PublicInnerClass = Architecture.GetClassOfType(typeof(OuterClass.PublicInnerClass));
+        OtherPublicInnerClass = Architecture.GetClassOfType(
+            typeof(OuterClass.OtherPublicInnerClass)
+        );
+        InternalInnerClass = Architecture.Classes.WhereNameIs("InternalInnerClass").First();
+        OtherInternalInnerClass = Architecture
+            .Classes.WhereNameIs("OtherInternalInnerClass")
+            .First();
+        ProtectedInternalInnerClass = Architecture
+            .Classes.WhereNameIs("ProtectedInternalInnerClass")
+            .First();
+        OtherProtectedInternalInnerClass = Architecture
+            .Classes.WhereNameIs("OtherProtectedInternalInnerClass")
+            .First();
+        ProtectedInnerClass = Architecture.Classes.WhereNameIs("ProtectedInnerClass").First();
+        OtherProtectedInnerClass = Architecture
+            .Classes.WhereNameIs("OtherProtectedInnerClass")
+            .First();
+        PrivateProtectedInnerClass = Architecture
+            .Classes.WhereNameIs("PrivateProtectedInnerClass")
+            .First();
+        OtherPrivateProtectedInnerClass = Architecture
+            .Classes.WhereNameIs("OtherPrivateProtectedInnerClass")
+            .First();
+        PrivateInnerClass = Architecture.Classes.WhereNameIs("PrivateInnerClass").First();
+        OtherPrivateInnerClass = Architecture.Classes.WhereNameIs("OtherPrivateInnerClass").First();
+    }
+}

--- a/ArchUnitNETTests/Dependencies/PropertyDependencyTests.cs
+++ b/ArchUnitNETTests/Dependencies/PropertyDependencyTests.cs
@@ -45,7 +45,7 @@ namespace ArchUnitNETTests.Dependencies
             }
             else
             {
-                Assert.True(false, "Property must have a getter");
+                Assert.Fail("Property must have a getter");
             }
         }
 
@@ -61,7 +61,7 @@ namespace ArchUnitNETTests.Dependencies
             }
             else
             {
-                Assert.True(false, "Property must have a getter");
+                Assert.Fail("Property must have a getter");
             }
         }
 
@@ -100,7 +100,7 @@ namespace ArchUnitNETTests.Dependencies
                 .ToList();
             if (methodCalls.IsNullOrEmpty())
             {
-                Assert.True(false, "Class must have Method Call Dependency");
+                Assert.Fail("Class must have Method Call Dependency");
             }
             Assert.Contains(_dependOnClass, methodCalls.Select(d => d.Target));
         }
@@ -113,7 +113,7 @@ namespace ArchUnitNETTests.Dependencies
                 .ToList();
             if (methodCalls.IsNullOrEmpty())
             {
-                Assert.True(false, "Property must have Method Call Dependency");
+                Assert.Fail("Property must have Method Call Dependency");
             }
             Assert.Contains(_dependOnClass, methodCalls.Select(d => d.Target));
         }
@@ -126,7 +126,7 @@ namespace ArchUnitNETTests.Dependencies
                 .ToList();
             if (methodCalls.IsNullOrEmpty())
             {
-                Assert.True(false, "Getter must have Method Call Dependency");
+                Assert.Fail("Getter must have Method Call Dependency");
             }
             Assert.Contains(_dependOnClass, methodCalls.Select(d => d.Target));
         }

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/ObjectsShouldTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/ObjectsShouldTests.cs
@@ -2890,7 +2890,7 @@ public class ObjectsShouldTests
         should = Types().That().Are(helper.ClassWithMultipleDependencies).Should();
         should
             .OnlyDependOn(typeof(AttributeNamespace.ClassWithoutAttributes))
-            .AssertNoViolations(helper);
+            .AssertOnlyViolations(helper);
 
         helper.AddSnapshotHeader("Empty arguments");
         should = Types().That().Are(helper.ClassWithMultipleDependencies).Should();

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/ObjectsShouldTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/ObjectsShouldTests.cs
@@ -538,7 +538,7 @@ public class ObjectsShouldTests
             )
             .AssertOnlyViolations(helper);
 
-        helper.AddSnapshotHeader("Multiple inputs");
+        helper.AddSnapshotHeader("Input with multiple dependencies");
         MethodMembers()
             .That()
             .Are(helper.MethodWithMultipleDependencies)
@@ -2110,7 +2110,7 @@ public class ObjectsShouldTests
             .NotHaveAnyAttributesWithArguments([helper.Attribute1Parameter2Value])
             .AssertOnlyViolations(helper);
 
-        helper.AddSnapshotHeader("Type without attrubites");
+        helper.AddSnapshotHeader("Type without attributes");
         should = Types().That().Are(helper.ClassWithoutAttributes).Should();
         should
             .NotHaveAnyAttributesWithArguments(helper.Attribute1Parameter1Value)
@@ -2887,7 +2887,7 @@ public class ObjectsShouldTests
         should.OnlyDependOn([helper.NonExistentObjectName]).AssertOnlyViolations(helper);
 
         helper.AddSnapshotHeader("Type outside of architecture");
-        should = Types().That().Are(helper.BaseClass).Should();
+        should = Types().That().Are(helper.ClassWithMultipleDependencies).Should();
         should
             .OnlyDependOn(typeof(AttributeNamespace.ClassWithoutAttributes))
             .AssertNoViolations(helper);

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/ObjectsShouldTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/ObjectsShouldTests.cs
@@ -1,0 +1,3229 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Fluent.Conditions;
+using ArchUnitNETTests.AssemblyTestHelper;
+using Xunit;
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+namespace ArchUnitNETTests.Fluent.Syntax.Elements;
+
+public class ObjectsShouldTests
+{
+    [Fact]
+    public async Task BeTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ChildClass).Should();
+        should.Be(helper.ChildClass.FullName).AssertNoViolations(helper);
+        should.Be("^.*\\.ChildClass$", true).AssertNoViolations(helper);
+        should.Be([helper.ChildClass.FullName]).AssertNoViolations(helper);
+        should.Be(["^.*\\.ChildClass$"], true).AssertNoViolations(helper);
+        should.Be(helper.ChildClass).AssertNoViolations(helper);
+        should.Be(helper.ChildClassSystemType).AssertNoViolations(helper);
+        should.Be(Classes().That().Are(helper.ChildClass)).AssertNoViolations(helper);
+        should.Be([helper.ChildClass]).AssertNoViolations(helper);
+        should.Be([helper.ChildClassSystemType]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ChildClass).Should();
+        should.Be(helper.ClassWithoutDependencies.FullName).AssertOnlyViolations(helper);
+        should.Be("^.*\\.ClassWithoutDependencies$", true).AssertOnlyViolations(helper);
+        should.Be([helper.ClassWithoutDependencies.FullName]).AssertOnlyViolations(helper);
+        should.Be(["^.*\\.ClassWithoutDependencies$"], true).AssertOnlyViolations(helper);
+        should.Be(helper.ClassWithoutDependencies).AssertOnlyViolations(helper);
+        should.Be(helper.ClassWithoutDependenciesSystemType).AssertOnlyViolations(helper);
+        should
+            .Be(Classes().That().Are(helper.ClassWithoutDependencies))
+            .AssertOnlyViolations(helper);
+        should.Be([helper.ClassWithoutDependencies]).AssertOnlyViolations(helper);
+        should.Be([helper.ClassWithoutDependenciesSystemType]).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent type");
+        should = Types().That().Are(helper.BaseClass).Should();
+        should.Be(helper.NonExistentObjectName).AssertOnlyViolations(helper);
+        should.Be([helper.NonExistentObjectName]).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.BaseClass).Should();
+        should.Be(new List<string>()).AssertOnlyViolations(helper);
+        should.Be(new List<IType>()).AssertOnlyViolations(helper);
+        should.Be(new List<System.Type>()).AssertOnlyViolations(helper);
+        should.Be(Classes().That().Are(helper.NonExistentObjectName)).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ChildClass).Should();
+        should
+            .Be([helper.ClassWithoutDependencies.FullName, helper.BaseClass.FullName])
+            .AssertOnlyViolations(helper);
+        should.Be(helper.ClassWithoutDependencies, helper.BaseClass).AssertOnlyViolations(helper);
+        should.Be([helper.ClassWithoutDependencies, helper.BaseClass]).AssertOnlyViolations(helper);
+        should
+            .Be(helper.ClassWithoutDependenciesSystemType, helper.BaseClassSystemType)
+            .AssertOnlyViolations(helper);
+        should
+            .Be([helper.ClassWithoutDependenciesSystemType, helper.BaseClassSystemType])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.ChildClass, helper.BaseClass)
+            .Should()
+            .Be(helper.ChildClass, helper.BaseClass)
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ChildClass, helper.BaseClass)
+            .Should()
+            .Be(helper.ChildClass, helper.ClassWithoutDependencies)
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task BeInternalTest()
+    {
+        var helper = new VisibilityAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        Types().That().Are(helper.InternalClass).Should().BeInternal().AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.InternalInnerClass)
+            .Should()
+            .BeInternal()
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        Types().That().Are(helper.PublicClass).Should().BeInternal().AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PublicInnerClass)
+            .Should()
+            .BeInternal()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInnerClass)
+            .Should()
+            .BeInternal()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInternalInnerClass)
+            .Should()
+            .BeInternal()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateInnerClass)
+            .Should()
+            .BeInternal()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateProtectedInnerClass)
+            .Should()
+            .BeInternal()
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.InternalClass, helper.OtherInternalClass)
+            .Should()
+            .BeInternal()
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.InternalClass, helper.ProtectedInternalInnerClass)
+            .Should()
+            .BeInternal()
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task BePrivateTest()
+    {
+        var helper = new VisibilityAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        Types()
+            .That()
+            .Are(helper.PrivateInnerClass)
+            .Should()
+            .BePrivate()
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        Types().That().Are(helper.PublicClass).Should().BePrivate().AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PublicInnerClass)
+            .Should()
+            .BePrivate()
+            .AssertOnlyViolations(helper);
+        Types().That().Are(helper.InternalClass).Should().BePrivate().AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.InternalInnerClass)
+            .Should()
+            .BePrivate()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInnerClass)
+            .Should()
+            .BePrivate()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInternalInnerClass)
+            .Should()
+            .BePrivate()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateProtectedInnerClass)
+            .Should()
+            .BePrivate()
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.PrivateInnerClass, helper.OtherPrivateInnerClass)
+            .Should()
+            .BePrivate()
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateInnerClass, helper.PrivateProtectedInnerClass)
+            .Should()
+            .BePrivate()
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task BePrivateProtectedTest()
+    {
+        var helper = new VisibilityAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        Types()
+            .That()
+            .Are(helper.PrivateProtectedInnerClass)
+            .Should()
+            .BePrivateProtected()
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        Types()
+            .That()
+            .Are(helper.PublicClass)
+            .Should()
+            .BePrivateProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PublicInnerClass)
+            .Should()
+            .BePrivateProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInnerClass)
+            .Should()
+            .BePrivateProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInternalInnerClass)
+            .Should()
+            .BePrivateProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.InternalClass)
+            .Should()
+            .BePrivateProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.InternalInnerClass)
+            .Should()
+            .BePrivateProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateInnerClass)
+            .Should()
+            .BePrivateProtected()
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.PrivateProtectedInnerClass, helper.OtherPrivateProtectedInnerClass)
+            .Should()
+            .BePrivateProtected()
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateProtectedInnerClass, helper.PrivateInnerClass)
+            .Should()
+            .BePrivateProtected()
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task BeProtectedTest()
+    {
+        var helper = new VisibilityAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        Types()
+            .That()
+            .Are(helper.ProtectedInnerClass)
+            .Should()
+            .BeProtected()
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        Types().That().Are(helper.PublicClass).Should().BeProtected().AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PublicInnerClass)
+            .Should()
+            .BeProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.InternalClass)
+            .Should()
+            .BeProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.InternalInnerClass)
+            .Should()
+            .BeProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateInnerClass)
+            .Should()
+            .BeProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateProtectedInnerClass)
+            .Should()
+            .BeProtected()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInternalInnerClass)
+            .Should()
+            .BeProtected()
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.ProtectedInnerClass, helper.OtherProtectedInnerClass)
+            .Should()
+            .BeProtected()
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInnerClass, helper.ProtectedInternalInnerClass)
+            .Should()
+            .BeProtected()
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task BeProtectedInternalTest()
+    {
+        var helper = new VisibilityAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        Types()
+            .That()
+            .Are(helper.ProtectedInternalInnerClass)
+            .Should()
+            .BeProtectedInternal()
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        Types()
+            .That()
+            .Are(helper.PublicClass)
+            .Should()
+            .BeProtectedInternal()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PublicInnerClass)
+            .Should()
+            .BeProtectedInternal()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInnerClass)
+            .Should()
+            .BeProtectedInternal()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.InternalClass)
+            .Should()
+            .BeProtectedInternal()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.InternalInnerClass)
+            .Should()
+            .BeProtectedInternal()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateInnerClass)
+            .Should()
+            .BeProtectedInternal()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateProtectedInnerClass)
+            .Should()
+            .BeProtectedInternal()
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.ProtectedInternalInnerClass, helper.OtherProtectedInternalInnerClass)
+            .Should()
+            .BeProtectedInternal()
+            .AssertNoViolations(helper);
+
+        Types()
+            .That()
+            .Are(helper.ProtectedInternalInnerClass, helper.InternalClass)
+            .Should()
+            .BeProtectedInternal()
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task BePublicTest()
+    {
+        var helper = new VisibilityAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        Types().That().Are(helper.PublicClass).Should().BePublic().AssertNoViolations(helper);
+        Types().That().Are(helper.PublicInnerClass).Should().BePublic().AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        Types().That().Are(helper.InternalClass).Should().BePublic().AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.InternalInnerClass)
+            .Should()
+            .BePublic()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInnerClass)
+            .Should()
+            .BePublic()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ProtectedInternalInnerClass)
+            .Should()
+            .BePublic()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateInnerClass)
+            .Should()
+            .BePublic()
+            .AssertOnlyViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PrivateProtectedInnerClass)
+            .Should()
+            .BePublic()
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.PublicClass, helper.OtherPublicClass)
+            .Should()
+            .BePublic()
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.PublicClass, helper.InternalClass)
+            .Should()
+            .BePublic()
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task CallAnyTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = MethodMembers().That().Are(helper.MethodWithSingleDependency).Should();
+        should.CallAny(helper.CalledMethod.FullName).AssertNoViolations(helper);
+        should.CallAny("^.*::CalledMethod\\(\\)$", true).AssertNoViolations(helper);
+        should.CallAny([helper.CalledMethod.FullName]).AssertNoViolations(helper);
+        should.CallAny(["^.*::CalledMethod\\(\\)$"], true).AssertNoViolations(helper);
+        should.CallAny(helper.CalledMethod).AssertNoViolations(helper);
+        should.CallAny([helper.CalledMethod]).AssertNoViolations(helper);
+        should.CallAny(MethodMembers().That().Are(helper.CalledMethod)).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = MethodMembers().That().Are(helper.MethodWithSingleDependency).Should();
+        should.CallAny(helper.MethodWithoutDependencies.FullName).AssertOnlyViolations(helper);
+        should.CallAny([helper.MethodWithoutDependencies.FullName]).AssertOnlyViolations(helper);
+        should.CallAny(helper.MethodWithoutDependencies).AssertOnlyViolations(helper);
+        should.CallAny([helper.MethodWithoutDependencies]).AssertOnlyViolations(helper);
+        should
+            .CallAny(MethodMembers().That().Are(helper.MethodWithoutDependencies))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent method member");
+        should = MethodMembers().That().Are(helper.MethodWithSingleDependency).Should();
+        should.CallAny(helper.NonExistentObjectName).AssertOnlyViolations(helper);
+        should.CallAny([helper.NonExistentObjectName]).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = MethodMembers().That().Are(helper.MethodWithSingleDependency).Should();
+        should.CallAny(new List<string>()).AssertOnlyViolations(helper);
+        should.CallAny(new List<MethodMember>()).AssertOnlyViolations(helper);
+        should
+            .CallAny(MethodMembers().That().Are(helper.NonExistentObjectName))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = MethodMembers().That().Are(helper.MethodWithMultipleDependencies).Should();
+        should
+            .CallAny(
+                [
+                    helper.MethodWithoutDependencies.FullName,
+                    helper.MethodWithMultipleDependencies.FullName
+                ]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .CallAny(helper.MethodWithoutDependencies, helper.MethodWithMultipleDependencies)
+            .AssertOnlyViolations(helper);
+        should
+            .CallAny([helper.MethodWithoutDependencies, helper.MethodWithMultipleDependencies])
+            .AssertOnlyViolations(helper);
+        should
+            .CallAny(
+                MethodMembers()
+                    .That()
+                    .Are(helper.MethodWithoutDependencies, helper.MethodWithMultipleDependencies)
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        MethodMembers()
+            .That()
+            .Are(helper.MethodWithMultipleDependencies)
+            .Should()
+            .CallAny(helper.CalledMethod1, helper.MethodWithoutDependencies)
+            .AssertNoViolations(helper);
+        MethodMembers()
+            .That()
+            .Are(helper.MethodWithMultipleDependencies)
+            .Should()
+            .CallAny(helper.MethodWithoutDependencies)
+            .AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task DependOnAnyTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ChildClass).Should();
+        should.DependOnAny(helper.BaseClass.FullName).AssertNoViolations(helper);
+        should.DependOnAny("^.*\\.BaseClass$", true).AssertNoViolations(helper);
+        should.DependOnAny([helper.BaseClass.FullName]).AssertNoViolations(helper);
+        should.DependOnAny(["^.*\\.BaseClass$"], true).AssertNoViolations(helper);
+        should.DependOnAny(helper.BaseClass).AssertNoViolations(helper);
+        should.DependOnAny(helper.BaseClassSystemType).AssertNoViolations(helper);
+        should.DependOnAny(Classes().That().Are(helper.BaseClass)).AssertNoViolations(helper);
+        should.DependOnAny([helper.BaseClass]).AssertNoViolations(helper);
+        should.DependOnAny([helper.BaseClassSystemType]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies.FullName).Should();
+        should.DependOnAny(helper.ClassWithoutDependencies.FullName).AssertOnlyViolations(helper);
+        should.DependOnAny([helper.ClassWithoutDependencies.FullName]).AssertOnlyViolations(helper);
+        should.DependOnAny(helper.ClassWithoutDependencies).AssertOnlyViolations(helper);
+        should.DependOnAny(helper.ClassWithoutDependenciesSystemType).AssertOnlyViolations(helper);
+        should
+            .DependOnAny(Classes().That().Are(helper.ClassWithoutDependencies))
+            .AssertOnlyViolations(helper);
+        should.DependOnAny([helper.ClassWithoutDependencies]).AssertOnlyViolations(helper);
+        should
+            .DependOnAny([helper.ClassWithoutDependenciesSystemType])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent type");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies.FullName).Should();
+        should.DependOnAny(helper.NonExistentObjectName).AssertOnlyViolations(helper);
+        should.DependOnAny([helper.NonExistentObjectName]).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Type outside of architecture");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies.FullName).Should();
+        should
+            .DependOnAny(typeof(AttributeNamespace.ClassWithoutAttributes))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies.FullName).Should();
+        should.DependOnAny(new List<string>()).AssertOnlyViolations(helper);
+        should.DependOnAny(new List<IType>()).AssertOnlyViolations(helper);
+        should.DependOnAny(new List<System.Type>()).AssertOnlyViolations(helper);
+        should
+            .DependOnAny(Classes().That().Are(helper.NonExistentObjectName))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies.FullName).Should();
+        should
+            .DependOnAny([helper.ClassWithoutDependencies.FullName, helper.BaseClass.FullName])
+            .AssertOnlyViolations(helper);
+        should
+            .DependOnAny(helper.ClassWithoutDependencies, helper.BaseClass)
+            .AssertOnlyViolations(helper);
+        should
+            .DependOnAny([helper.ClassWithoutDependencies, helper.BaseClass])
+            .AssertOnlyViolations(helper);
+        should
+            .DependOnAny(helper.ClassWithoutDependenciesSystemType, helper.BaseClassSystemType)
+            .AssertOnlyViolations(helper);
+        should
+            .DependOnAny([helper.ClassWithoutDependenciesSystemType, helper.BaseClassSystemType])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Input without dependencies");
+        should = Types().That().Are(helper.ClassWithoutDependencies).Should();
+        should
+            .DependOnAny([helper.BaseClass.FullName, helper.ChildClass.FullName])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.ChildClass1, helper.ChildClass2)
+            .Should()
+            .DependOnAny(helper.BaseClassWithMultipleDependenciesSystemType)
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ChildClass, helper.BaseClass)
+            .Should()
+            .DependOnAny(helper.ClassWithoutDependencies)
+            .AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task DependOnAnyTypesThatTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        Types()
+            .That()
+            .Are(helper.ChildClass)
+            .Should()
+            .DependOnAnyTypesThat()
+            .Are(helper.BaseClass)
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        Types()
+            .That()
+            .Are(helper.BaseClass)
+            .Should()
+            .DependOnAnyTypesThat()
+            .Are(helper.ChildClass)
+            .AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task ExistTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        Types().That().Are(helper.BaseClass).Should().Exist().AssertNoViolations(helper);
+        Types().That().Are(helper.BaseClassSystemType).Should().Exist().AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        Types()
+            .That()
+            .Are(helper.NonExistentObjectName)
+            .Should()
+            .Exist()
+            .AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    class CustomCondition : ICondition<IType>
+    {
+        public string Description => "follow custom condition";
+
+        public IEnumerable<ConditionResult> Check(
+            IEnumerable<IType> objects,
+            Architecture architecture
+        )
+        {
+            return objects.Select(t => new ConditionResult(
+                t,
+                t.Name == "ChildClass",
+                "does not follow custom condition"
+            ));
+        }
+
+        public bool CheckEmpty()
+        {
+            return true;
+        }
+    }
+
+    [Fact]
+    public async Task FollowCustomConditionTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ChildClass).Should();
+        should.FollowCustomCondition(new CustomCondition()).AssertNoViolations(helper);
+        should
+            .FollowCustomCondition(
+                t => new ConditionResult(
+                    t,
+                    t.Name == "ChildClass",
+                    "does not follow custom condition"
+                ),
+                "follow custom condition"
+            )
+            .AssertNoViolations(helper);
+        should
+            .FollowCustomCondition(
+                t => t.Name == "ChildClass",
+                "follow custom condition",
+                "does not follow custom condition"
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.BaseClass).Should();
+        should.FollowCustomCondition(new CustomCondition()).AssertOnlyViolations(helper);
+        should
+            .FollowCustomCondition(
+                t => new ConditionResult(
+                    t,
+                    t.Name == "ChildClass",
+                    "does not follow custom condition"
+                ),
+                "follow custom condition"
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .FollowCustomCondition(
+                t => t.Name == "ChildClass",
+                "follow custom condition",
+                "does not follow custom condition"
+            )
+            .AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task HaveAnyAttributesTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should.HaveAnyAttributes(helper.Attribute1.FullName).AssertNoViolations(helper);
+        should.HaveAnyAttributes("^.*\\.Attribute1$", true).AssertNoViolations(helper);
+        should.HaveAnyAttributes([helper.Attribute1.FullName]).AssertNoViolations(helper);
+        should.HaveAnyAttributes(["^.*\\.Attribute1$"], true).AssertNoViolations(helper);
+        should.HaveAnyAttributes(helper.Attribute1).AssertNoViolations(helper);
+        should.HaveAnyAttributes([helper.Attribute1]).AssertNoViolations(helper);
+        should.HaveAnyAttributes(helper.Attribute1SystemType).AssertNoViolations(helper);
+        should.HaveAnyAttributes([helper.Attribute1SystemType]).AssertNoViolations(helper);
+        should
+            .HaveAnyAttributes(Attributes().That().Are(helper.Attribute1))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should.HaveAnyAttributes(helper.UnusedAttribute.FullName).AssertOnlyViolations(helper);
+        should.HaveAnyAttributes([helper.UnusedAttribute.FullName]).AssertOnlyViolations(helper);
+        should.HaveAnyAttributes(helper.UnusedAttribute).AssertOnlyViolations(helper);
+        should.HaveAnyAttributes([helper.UnusedAttribute]).AssertOnlyViolations(helper);
+        should.HaveAnyAttributes(helper.UnusedAttributeSystemType).AssertOnlyViolations(helper);
+        should.HaveAnyAttributes([helper.UnusedAttributeSystemType]).AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributes(Attributes().That().Are(helper.UnusedAttribute))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent attribute");
+        should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should.HaveAnyAttributes(helper.NonExistentObjectName).AssertOnlyViolations(helper);
+        should.HaveAnyAttributes([helper.NonExistentObjectName]).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should.HaveAnyAttributes(new List<string>()).AssertOnlyViolations(helper);
+        should.HaveAnyAttributes(new List<Attribute>()).AssertOnlyViolations(helper);
+        should.HaveAnyAttributes(new List<System.Type>()).AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributes(Attributes().That().Are(helper.NonExistentObjectName))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should
+            .HaveAnyAttributes([helper.Attribute1.FullName, helper.UnusedAttribute.FullName])
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributes(helper.Attribute1, helper.UnusedAttribute)
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributes([helper.Attribute1, helper.UnusedAttribute])
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributes(helper.Attribute1SystemType, helper.UnusedAttributeSystemType)
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributes([helper.Attribute1SystemType, helper.UnusedAttributeSystemType])
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributes(Attributes().That().Are(helper.Attribute1, helper.UnusedAttribute))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.ClassWithAttributes, helper.OtherClassWithAttributes)
+            .Should()
+            .HaveAnyAttributes(helper.Attribute1)
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ClassWithAttributes, helper.ClassWithoutAttributes)
+            .Should()
+            .HaveAnyAttributes(helper.Attribute1)
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task HaveAnyAttributesThatTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should.HaveAnyAttributesThat().Are(helper.Attribute1).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should.HaveAnyAttributesThat().Are(helper.UnusedAttribute).AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task HaveAnyAttributesWithArgumentsTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations with type arguments");
+        var should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAnyAttributesWithArguments(helper.Attribute1Parameter3Value)
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributesWithArguments([helper.Attribute1Parameter3Value])
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("No violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAnyAttributesWithArguments(helper.Attribute1Parameter1Value)
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributesWithArguments([helper.Attribute1Parameter1Value])
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with type arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAnyAttributesWithArguments(helper.UnusedTypeParameterValue)
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributesWithArguments([helper.UnusedTypeParameterValue])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with value arguments");
+        should = Types().That().Are(helper.ClassWithoutAttributes).Should();
+        should
+            .HaveAnyAttributesWithArguments(helper.Attribute1Parameter2Value)
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributesWithArguments([helper.Attribute1Parameter2Value])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Null argument");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should.HaveAnyAttributesWithArguments(null).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        Types()
+            .That()
+            .Are(helper.ClassWithArguments)
+            .Should()
+            .HaveAnyAttributesWithArguments([])
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ClassWithAttributes)
+            .Should()
+            .HaveAnyAttributesWithArguments([])
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAnyAttributesWithArguments(
+                [helper.Attribute1Parameter3InvalidValue, helper.UnusedParameterValue]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributesWithArguments(
+                helper.Attribute1Parameter3InvalidValue,
+                helper.UnusedParameterValue
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.ClassWithArguments, helper.OtherClassWithArguments)
+            .Should()
+            .HaveAnyAttributesWithArguments(helper.Attribute1Parameter1Value)
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ClassWithArguments, helper.ClassWithAttributes)
+            .Should()
+            .HaveAnyAttributesWithArguments(helper.Attribute1Parameter2Value)
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task HaveAnyAttributesWithNamedArguments()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations with type arguments");
+        var should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter1Pair)
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments([helper.Attribute1NamedParameter1Pair])
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("No violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter2Pair)
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments([helper.Attribute1NamedParameter2Pair])
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with type arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter1InvalidNamePair)
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments([helper.Attribute1NamedParameter1InvalidNamePair])
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter1InvalidValuePair)
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments([helper.Attribute1NamedParameter1InvalidValuePair])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter2InvalidNamePair)
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments([helper.Attribute1NamedParameter2InvalidNamePair])
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter2InvalidValuePair)
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments([helper.Attribute1NamedParameter2InvalidValuePair])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should.HaveAnyAttributesWithNamedArguments([]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAnyAttributesWithNamedArguments(
+                helper.Attribute1NamedParameter1Pair,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments(
+                [helper.Attribute1NamedParameter1Pair, helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments(
+                helper.Attribute1NamedParameter1Pair,
+                helper.Attribute1NamedParameter2InvalidValuePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments(
+                [
+                    helper.Attribute1NamedParameter1Pair,
+                    helper.Attribute1NamedParameter2InvalidValuePair
+                ]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        should = Types().That().Are(helper.ClassWithArguments, helper.ClassWithAttributes).Should();
+        should
+            .HaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter1Pair)
+            .AssertAnyViolations(helper);
+        should
+            .HaveAnyAttributesWithNamedArguments([helper.Attribute1NamedParameter1Pair])
+            .AssertAnyViolations(helper);
+
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task HaveAttributeWithArgumentsTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations with type arguments");
+        var should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1Parameter3Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1Parameter3Value]
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(helper.Attribute1, helper.Attribute1Parameter3Value)
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(helper.Attribute1, [helper.Attribute1Parameter3Value])
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1Parameter3Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1Parameter3Value]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("No violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1Parameter1Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1Parameter1Value]
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(helper.Attribute1, helper.Attribute1Parameter1Value)
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(helper.Attribute1, [helper.Attribute1Parameter1Value])
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1Parameter1Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1Parameter1Value]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with type arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1Parameter3InvalidValue
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1Parameter3InvalidValue]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(helper.Attribute1, helper.Attribute1Parameter3InvalidValue)
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1,
+                [helper.Attribute1Parameter3InvalidValue]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1Parameter3InvalidValue
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1Parameter3InvalidValue]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute2Parameter2Value
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute2Parameter2Value]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(helper.Attribute1, helper.Attribute2Parameter2Value)
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(helper.Attribute1, [helper.Attribute2Parameter2Value])
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute2Parameter2Value
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute2Parameter2Value]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent attribute");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithArguments(
+                helper.NonExistentObjectName,
+                helper.Attribute1Parameter1Value
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Type outside of architecture");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithArguments(
+                typeof(TypeDependencyNamespace.BaseClass),
+                helper.Attribute1Parameter1Value
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Null argument");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithArguments(helper.Attribute1.FullName, null)
+            .AssertOnlyViolations(helper);
+        should.HaveAttributeWithArguments(helper.Attribute1, null).AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithArguments(helper.Attribute1SystemType, null)
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithArguments(helper.Attribute1.FullName, new List<object>())
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(helper.Attribute1, new List<object>())
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(helper.Attribute1SystemType, new List<object>())
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1Parameter1Value, helper.Attribute1Parameter2Value]
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1,
+                helper.Attribute1Parameter1Value,
+                helper.Attribute1Parameter2Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1,
+                [helper.Attribute1Parameter1Value, helper.Attribute1Parameter2Value]
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1Parameter1Value,
+                helper.Attribute1Parameter2Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1Parameter1Value, helper.Attribute1Parameter2Value]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.ClassWithArguments, helper.OtherClassWithArguments)
+            .Should()
+            .HaveAttributeWithArguments(helper.Attribute1, helper.Attribute1Parameter1Value)
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ClassWithArguments, helper.ClassWithAttributes)
+            .Should()
+            .HaveAttributeWithArguments(helper.Attribute1, helper.Attribute1Parameter2Value)
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task HaveAttributeWithNamedArguments()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations with type arguments");
+        var should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("No violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with type arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter1InvalidNamePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter1InvalidNamePair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter1InvalidNamePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter1InvalidNamePair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter1InvalidNamePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter1InvalidNamePair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter1InvalidValuePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter1InvalidValuePair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter1InvalidValuePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter1InvalidValuePair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter1InvalidValuePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter1InvalidValuePair]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter2InvalidNamePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter2InvalidNamePair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter2InvalidNamePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter2InvalidNamePair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter2InvalidNamePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter2InvalidNamePair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter2InvalidValuePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter2InvalidValuePair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter2InvalidValuePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter2InvalidValuePair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter2InvalidValuePair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter2InvalidValuePair]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Unused attribute");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.UnusedAttribute.FullName,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.UnusedAttribute.FullName,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.UnusedAttribute,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.UnusedAttribute,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.UnusedAttributeSystemType,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.UnusedAttributeSystemType,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Type outside of architecture");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithNamedArguments(
+                typeof(TypeDependencyNamespace.BaseClass),
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Emtpy arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithNamedArguments(helper.Attribute1.FullName, [])
+            .AssertNoViolations(helper);
+        should.HaveAttributeWithNamedArguments(helper.Attribute1, []).AssertNoViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(helper.Attribute1SystemType, [])
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter1Pair,
+                helper.Attribute2NamedParameter2Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter1Pair, helper.Attribute2NamedParameter2Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter1Pair,
+                helper.Attribute2NamedParameter2Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter1Pair, helper.Attribute2NamedParameter2Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter1Pair,
+                helper.Attribute2NamedParameter2Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter1Pair, helper.Attribute2NamedParameter2Pair]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        should = Types().That().Are(helper.ClassWithArguments, helper.ClassWithAttributes).Should();
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertAnyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertAnyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertAnyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertAnyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertAnyViolations(helper);
+        should
+            .HaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task HaveNameTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.BaseClass).Should();
+        should.HaveName(helper.BaseClass.Name).AssertNoViolations(helper);
+        should.HaveName("^Base.*$", true).AssertNoViolations(helper);
+        should.HaveFullName(helper.BaseClass.FullName).AssertNoViolations(helper);
+        should.HaveFullName("^.*\\.Base.*$", true).AssertNoViolations(helper);
+        should.HaveNameContaining("Base").AssertNoViolations(helper);
+        should.HaveFullNameContaining(helper.BaseClass.Namespace.Name).AssertNoViolations(helper);
+        should.HaveNameStartingWith("Base").AssertNoViolations(helper);
+        should.HaveNameEndingWith("Class").AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.BaseClass).Should();
+        should.HaveName(helper.BaseClass.FullName).AssertOnlyViolations(helper);
+        should.HaveName("^.*\\.Base.*$", false).AssertOnlyViolations(helper);
+        should.HaveFullName(helper.BaseClass.Name).AssertOnlyViolations(helper);
+        should.HaveFullName("^Base.*$", false).AssertOnlyViolations(helper);
+        should.HaveNameContaining(helper.BaseClass.Namespace.Name).AssertOnlyViolations(helper);
+        should.HaveFullNameContaining(helper.NonExistentObjectName).AssertOnlyViolations(helper);
+        should.HaveNameStartingWith(helper.BaseClass.Namespace.Name).AssertOnlyViolations(helper);
+        should.HaveNameEndingWith("Base").AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotBeTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().DependOnAny(helper.BaseClass.FullName).Should();
+        should.NotBe(helper.ClassWithoutDependencies.FullName).AssertNoViolations(helper);
+        should.NotBe("^.*\\.ClassWithoutDependencies$", true).AssertNoViolations(helper);
+        should.NotBe([helper.ClassWithoutDependencies.FullName]).AssertNoViolations(helper);
+        should.NotBe("^.*\\.ClassWithoutDependencies$", true).AssertNoViolations(helper);
+        should.NotBe(helper.ClassWithoutDependencies).AssertNoViolations(helper);
+        should.NotBe(helper.ClassWithoutDependenciesSystemType).AssertNoViolations(helper);
+        should
+            .NotBe(Classes().That().Are(helper.ClassWithoutDependencies))
+            .AssertNoViolations(helper);
+        should.NotBe([helper.ClassWithoutDependencies]).AssertNoViolations(helper);
+        should.NotBe([helper.ClassWithoutDependenciesSystemType]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().DependOnAny(helper.BaseClass.FullName).Should();
+        should.NotBe(helper.ChildClass.FullName).AssertAnyViolations(helper);
+        should.NotBe([helper.ChildClass.FullName]).AssertAnyViolations(helper);
+        should.NotBe(helper.ChildClass).AssertAnyViolations(helper);
+        should.NotBe(helper.ChildClassSystemType).AssertAnyViolations(helper);
+        should.NotBe(Classes().That().Are(helper.ChildClass)).AssertAnyViolations(helper);
+        should.NotBe([helper.ChildClass]).AssertAnyViolations(helper);
+        should.NotBe([helper.ChildClassSystemType]).AssertAnyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent type");
+        should = Types().That().DependOnAny(helper.BaseClass.FullName).Should();
+        should.NotBe(helper.NonExistentObjectName).AssertNoViolations(helper);
+        should.NotBe([helper.NonExistentObjectName]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().DependOnAny(helper.BaseClass.FullName).Should();
+        should.NotBe(new List<string>()).AssertNoViolations(helper);
+        should.NotBe(new List<IType>()).AssertNoViolations(helper);
+        should.NotBe(new List<System.Type>()).AssertNoViolations(helper);
+        should.NotBe(Classes().That().Are(helper.NonExistentObjectName)).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().DependOnAny(helper.BaseClass.FullName).Should();
+        should
+            .NotBe([helper.ClassWithoutDependencies.FullName, helper.BaseClass.FullName])
+            .AssertNoViolations(helper);
+        should.NotBe(helper.ClassWithoutDependencies, helper.BaseClass).AssertNoViolations(helper);
+        should
+            .NotBe([helper.ClassWithoutDependencies, helper.BaseClass])
+            .AssertNoViolations(helper);
+        should
+            .NotBe(helper.ClassWithoutDependenciesSystemType, helper.BaseClassSystemType)
+            .AssertNoViolations(helper);
+        should
+            .NotBe([helper.ClassWithoutDependenciesSystemType, helper.BaseClassSystemType])
+            .AssertNoViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotCallAnyTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = MethodMembers().That().Are(helper.MethodWithSingleDependency).Should();
+        should.NotCallAny(helper.MethodWithoutDependencies.FullName).AssertNoViolations(helper);
+        should.NotCallAny("^.*\\.MethodWithoutDependencies$", true).AssertNoViolations(helper);
+        should.NotCallAny([helper.MethodWithoutDependencies.FullName]).AssertNoViolations(helper);
+        should.NotCallAny("^.*\\.MethodWithoutDependencies$", true).AssertNoViolations(helper);
+        should.NotCallAny(helper.MethodWithoutDependencies).AssertNoViolations(helper);
+        should.NotCallAny([helper.MethodWithoutDependencies]).AssertNoViolations(helper);
+        should
+            .NotCallAny(MethodMembers().That().Are(helper.MethodWithoutDependencies))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = MethodMembers().That().Are(helper.MethodWithSingleDependency).Should();
+        should.NotCallAny(helper.CalledMethod.FullName).AssertOnlyViolations(helper);
+        should.NotCallAny([helper.CalledMethod.FullName]).AssertOnlyViolations(helper);
+        should.NotCallAny(helper.CalledMethod).AssertOnlyViolations(helper);
+        should.NotCallAny([helper.CalledMethod]).AssertOnlyViolations(helper);
+        should
+            .NotCallAny(MethodMembers().That().Are(helper.CalledMethod))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent method member");
+        should = MethodMembers().That().Are(helper.MethodWithSingleDependency).Should();
+        should.NotCallAny(helper.NonExistentObjectName).AssertNoViolations(helper);
+        should.NotCallAny([helper.NonExistentObjectName]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = MethodMembers().That().Are(helper.MethodWithSingleDependency).Should();
+        should.NotCallAny(new List<string>()).AssertNoViolations(helper);
+        should.NotCallAny(new List<MethodMember>()).AssertNoViolations(helper);
+        should
+            .NotCallAny(MethodMembers().That().Are(helper.NonExistentObjectName))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = MethodMembers().That().Are(helper.MethodWithMultipleDependencies).Should();
+        should
+            .NotCallAny("^.*::(MethodWithoutDependencies|CalledMethod[0-9])\\(\\)$", true)
+            .AssertOnlyViolations(helper);
+        should
+            .NotCallAny(
+                [
+                    helper.MethodWithoutDependencies.FullName,
+                    helper.CalledMethod1.FullName,
+                    helper.CalledMethod2.FullName
+                ]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotCallAny(
+                helper.MethodWithoutDependencies,
+                helper.CalledMethod1,
+                helper.CalledMethod2
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotCallAny(
+                [helper.MethodWithoutDependencies, helper.CalledMethod1, helper.CalledMethod2]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotCallAny(
+                MethodMembers()
+                    .That()
+                    .Are(
+                        helper.MethodWithoutDependencies,
+                        helper.CalledMethod1,
+                        helper.CalledMethod2
+                    )
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        MethodMembers()
+            .That()
+            .Are(helper.MethodWithSingleDependency, helper.MethodWithMultipleDependencies)
+            .Should()
+            .NotCallAny(helper.MethodWithoutDependencies)
+            .AssertNoViolations(helper);
+        MethodMembers()
+            .That()
+            .Are(helper.MethodWithSingleDependency, helper.MethodWithMultipleDependencies)
+            .Should()
+            .NotCallAny(helper.CalledMethod, helper.CalledMethod1, helper.CalledMethod2)
+            .AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotDependOnAnyTypesThatTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        Types()
+            .That()
+            .Are(helper.BaseClass)
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .Are(helper.ChildClass)
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        Types()
+            .That()
+            .Are(helper.ChildClass)
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .Are(helper.BaseClass)
+            .AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotDependOnAnyTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ChildClass).Should();
+        should.NotDependOnAny(helper.ClassWithoutDependencies.FullName).AssertNoViolations(helper);
+        should.NotDependOnAny("^.*\\.ClassWithoutDependencies$", true).AssertNoViolations(helper);
+        should
+            .NotDependOnAny([helper.ClassWithoutDependencies.FullName])
+            .AssertNoViolations(helper);
+        should.NotDependOnAny("^.*\\.ClassWithoutDependencies$", true).AssertNoViolations(helper);
+        should.NotDependOnAny(helper.ClassWithoutDependencies).AssertNoViolations(helper);
+        should.NotDependOnAny(helper.ClassWithoutDependenciesSystemType).AssertNoViolations(helper);
+        should
+            .NotDependOnAny(Classes().That().Are(helper.ClassWithoutDependencies))
+            .AssertNoViolations(helper);
+        should.NotDependOnAny([helper.ClassWithoutDependencies]).AssertNoViolations(helper);
+        should
+            .NotDependOnAny([helper.ClassWithoutDependenciesSystemType])
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ChildClass).Should();
+        should.NotDependOnAny(helper.BaseClass.FullName).AssertOnlyViolations(helper);
+        should.NotDependOnAny([helper.BaseClass.FullName]).AssertOnlyViolations(helper);
+        should.NotDependOnAny(helper.BaseClass).AssertOnlyViolations(helper);
+        should.NotDependOnAny(helper.BaseClassSystemType).AssertOnlyViolations(helper);
+        should.NotDependOnAny(Classes().That().Are(helper.BaseClass)).AssertOnlyViolations(helper);
+        should.NotDependOnAny([helper.BaseClass]).AssertOnlyViolations(helper);
+        should.NotDependOnAny([helper.BaseClassSystemType]).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent type");
+        should = Types().That().Are(helper.ChildClass).Should();
+        should.NotDependOnAny(helper.NonExistentObjectName).AssertNoViolations(helper);
+        should.NotDependOnAny([helper.NonExistentObjectName]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Type outside of architecture");
+        should = Types().That().Are(helper.ChildClass).Should();
+        should
+            .NotDependOnAny(typeof(AttributeNamespace.ClassWithoutAttributes))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ChildClass).Should();
+        should.NotDependOnAny(new List<string>()).AssertNoViolations(helper);
+        should.NotDependOnAny(new List<IType>()).AssertNoViolations(helper);
+        should.NotDependOnAny(new List<System.Type>()).AssertNoViolations(helper);
+        should
+            .NotDependOnAny(Classes().That().Are(helper.NonExistentObjectName))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ChildClass).Should();
+        should
+            .NotDependOnAny([helper.ClassWithoutDependencies.FullName, helper.BaseClass.FullName])
+            .AssertOnlyViolations(helper);
+        should
+            .NotDependOnAny(helper.ClassWithoutDependencies, helper.BaseClass)
+            .AssertOnlyViolations(helper);
+        should
+            .NotDependOnAny([helper.ClassWithoutDependencies, helper.BaseClass])
+            .AssertOnlyViolations(helper);
+        should
+            .NotDependOnAny(helper.ClassWithoutDependenciesSystemType, helper.BaseClassSystemType)
+            .AssertOnlyViolations(helper);
+        should
+            .NotDependOnAny([helper.ClassWithoutDependenciesSystemType, helper.BaseClassSystemType])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Input with multiple dependencies");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies).Should();
+        should
+            .NotDependOnAny("^.*\\.(BaseClassWithMember|OtherBaseClass)$", true)
+            .AssertOnlyViolations(helper);
+        should
+            .NotDependOnAny([helper.BaseClassWithMember.FullName, helper.OtherBaseClass.FullName])
+            .AssertOnlyViolations(helper);
+        should
+            .NotDependOnAny(helper.BaseClassWithMember, helper.OtherBaseClass)
+            .AssertOnlyViolations(helper);
+        should
+            .NotDependOnAny([helper.BaseClassWithMember, helper.OtherBaseClass])
+            .AssertOnlyViolations(helper);
+        should
+            .NotDependOnAny(helper.BaseClassWithMemberSystemType, helper.OtherBaseClassSystemType)
+            .AssertOnlyViolations(helper);
+        should
+            .NotDependOnAny([helper.BaseClassWithMemberSystemType, helper.OtherBaseClassSystemType])
+            .AssertOnlyViolations(helper);
+        should
+            .NotDependOnAny(Classes().That().Are(helper.BaseClassWithMember, helper.OtherBaseClass))
+            .AssertOnlyViolations(helper);
+
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotExistTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().DependOnAny(helper.ChildClass).Should();
+        should.NotExist().AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().DependOnAny(helper.BaseClass).Should();
+        should.NotExist().AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotHaveAnyAttributesTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should.NotHaveAnyAttributes(helper.UnusedAttribute.FullName).AssertNoViolations(helper);
+        should.NotHaveAnyAttributes("^.*\\.UnusedAttribute$", true).AssertNoViolations(helper);
+        should.NotHaveAnyAttributes([helper.UnusedAttribute.FullName]).AssertNoViolations(helper);
+        should.NotHaveAnyAttributes("^.*\\.UnusedAttribute$", true).AssertNoViolations(helper);
+        should.NotHaveAnyAttributes(helper.UnusedAttribute).AssertNoViolations(helper);
+        should.NotHaveAnyAttributes([helper.UnusedAttribute]).AssertNoViolations(helper);
+        should.NotHaveAnyAttributes(helper.UnusedAttributeSystemType).AssertNoViolations(helper);
+        should.NotHaveAnyAttributes([helper.UnusedAttributeSystemType]).AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributes(Attributes().That().Are(helper.UnusedAttribute))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should.NotHaveAnyAttributes(helper.Attribute1.FullName).AssertOnlyViolations(helper);
+        should.NotHaveAnyAttributes([helper.Attribute1.FullName]).AssertOnlyViolations(helper);
+        should.NotHaveAnyAttributes(helper.Attribute1).AssertOnlyViolations(helper);
+        should.NotHaveAnyAttributes([helper.Attribute1]).AssertOnlyViolations(helper);
+        should.NotHaveAnyAttributes(helper.Attribute1SystemType).AssertOnlyViolations(helper);
+        should.NotHaveAnyAttributes([helper.Attribute1SystemType]).AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributes(Attributes().That().Are(helper.Attribute1))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent attribute");
+        should = Types().That().Are(helper.ClassWithoutAttributes).Should();
+        should.NotHaveAnyAttributes(helper.NonExistentObjectName).AssertNoViolations(helper);
+        should.NotHaveAnyAttributes([helper.NonExistentObjectName]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Type outside of architecture");
+        should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should
+            .NotHaveAnyAttributes(typeof(TypeDependencyNamespace.BaseClass))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithoutAttributes).Should();
+        should.NotHaveAnyAttributes(new List<string>()).AssertNoViolations(helper);
+        should.NotHaveAnyAttributes(new List<Attribute>()).AssertNoViolations(helper);
+        should.NotHaveAnyAttributes(new List<System.Type>()).AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributes(Attributes().That().Are(helper.NonExistentObjectName))
+            .AssertNoViolations(helper);
+        should = Types().That().Are(helper.NonExistentObjectName).Should();
+        should
+            .NotHaveAnyAttributes(new List<string>())
+            .WithoutRequiringPositiveResults()
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributes(new List<Attribute>())
+            .WithoutRequiringPositiveResults()
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributes(new List<System.Type>())
+            .WithoutRequiringPositiveResults()
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributes(Attributes().That().Are(helper.NonExistentObjectName))
+            .WithoutRequiringPositiveResults()
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should
+            .NotHaveAnyAttributes([helper.Attribute1.FullName, helper.Attribute2.FullName])
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributes(helper.Attribute1, helper.Attribute2)
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributes([helper.Attribute1, helper.Attribute2])
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributes(helper.Attribute1SystemType, helper.Attribute2SystemType)
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributes([helper.Attribute1SystemType, helper.Attribute2SystemType])
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributes(Attributes().That().Are(helper.Attribute1, helper.Attribute2))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        Types()
+            .That()
+            .Are(helper.ClassWithoutAttributes, helper.OtherClassWithoutAttributes)
+            .Should()
+            .NotHaveAnyAttributes(helper.Attribute2)
+            .AssertNoViolations(helper);
+        Types()
+            .That()
+            .Are(helper.ClassWithoutAttributes, helper.OtherClassWithAttributes)
+            .Should()
+            .NotHaveAnyAttributes(helper.Attribute1)
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotHaveAnyAttributesThatTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should.NotHaveAnyAttributesThat().Are(helper.UnusedAttribute).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should.NotHaveAnyAttributesThat().Are(helper.Attribute1).AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotHaveAnyAttributesWithArgumentsTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations with type arguments");
+        var should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAnyAttributesWithArguments(helper.UnusedTypeParameterValue)
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributesWithArguments([helper.UnusedTypeParameterValue])
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("No violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAnyAttributesWithArguments(helper.UnusedParameterValue)
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributesWithArguments([helper.UnusedParameterValue])
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with type arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAnyAttributesWithArguments(helper.Attribute1Parameter3Value)
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributesWithArguments([helper.Attribute1Parameter3Value])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAnyAttributesWithArguments(helper.Attribute1Parameter2Value)
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributesWithArguments([helper.Attribute1Parameter2Value])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Type without attrubites");
+        should = Types().That().Are(helper.ClassWithoutAttributes).Should();
+        should
+            .NotHaveAnyAttributesWithArguments(helper.Attribute1Parameter1Value)
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Null argument");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should.NotHaveAnyAttributesWithArguments(null).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should.NotHaveAnyAttributesWithArguments([]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAnyAttributesWithArguments(
+                [helper.UnusedTypeParameterValue, helper.Attribute1Parameter1Value]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributesWithArguments(
+                helper.UnusedTypeParameterValue,
+                helper.Attribute1Parameter1Value
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        should = Types().That().Are(helper.ClassWithArguments, helper.ClassWithAttributes).Should();
+        should
+            .NotHaveAnyAttributesWithArguments(helper.Attribute1Parameter1Value)
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAnyAttributesWithArguments([helper.Attribute1Parameter1Value])
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotHaveAnyAttributesWithNamedArgumentsTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations with type arguments");
+        var should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter1InvalidNamePair)
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributesWithNamedArguments(
+                [helper.Attribute1NamedParameter1InvalidNamePair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributesWithNamedArguments(
+                helper.Attribute1NamedParameter1InvalidValuePair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributesWithNamedArguments(
+                [helper.Attribute1NamedParameter1InvalidValuePair]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("No violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter2InvalidNamePair)
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributesWithNamedArguments(
+                [helper.Attribute1NamedParameter2InvalidNamePair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributesWithNamedArguments(
+                helper.Attribute1NamedParameter2InvalidValuePair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAnyAttributesWithNamedArguments(
+                [helper.Attribute1NamedParameter2InvalidValuePair]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with type arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter1Pair)
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributesWithNamedArguments([helper.Attribute1NamedParameter1Pair])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter2Pair)
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributesWithNamedArguments([helper.Attribute1NamedParameter2Pair])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should.NotHaveAnyAttributesWithNamedArguments([]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAnyAttributesWithNamedArguments(
+                [helper.Attribute1NamedParameter1Pair, helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAnyAttributesWithNamedArguments(
+                helper.Attribute1NamedParameter1Pair,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        should = Types().That().Are(helper.ClassWithArguments, helper.ClassWithAttributes).Should();
+        should
+            .NotHaveAnyAttributesWithNamedArguments(helper.Attribute1NamedParameter1Pair)
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAnyAttributesWithNamedArguments([helper.Attribute1NamedParameter1Pair])
+            .AssertAnyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotHaveAttributeWithArgumentsTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations with type arguments");
+        var should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute2Parameter1Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute2Parameter1Value]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1, helper.Attribute2Parameter1Value)
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1, [helper.Attribute2Parameter1Value])
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute2Parameter1Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute2Parameter1Value]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("No violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute2Parameter1Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute2Parameter1Value]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1, helper.Attribute2Parameter1Value)
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1, [helper.Attribute2Parameter1Value])
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute2Parameter1Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute2Parameter1Value]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with type arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1Parameter1Value
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1Parameter1Value]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1, helper.Attribute1Parameter1Value)
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1, [helper.Attribute1Parameter1Value])
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1Parameter1Value
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1Parameter1Value]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1Parameter2Value
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1Parameter2Value]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1, helper.Attribute1Parameter2Value)
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1, [helper.Attribute1Parameter2Value])
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1Parameter2Value
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1Parameter2Value]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Unused attribute");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithArguments(
+                helper.UnusedAttribute.FullName,
+                helper.Attribute1Parameter1Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.UnusedAttribute.FullName,
+                [helper.Attribute1Parameter1Value]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.UnusedAttribute, helper.Attribute1Parameter1Value)
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.UnusedAttribute,
+                [helper.Attribute1Parameter1Value]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.UnusedAttributeSystemType,
+                helper.Attribute1Parameter1Value
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.UnusedAttributeSystemType,
+                [helper.Attribute1Parameter1Value]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Type outside of architecture");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithArguments(typeof(TypeDependencyNamespace.BaseClass), 1)
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Null argument");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithArguments(helper.UnusedAttribute.FullName, null)
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.UnusedAttribute, null)
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.UnusedAttributeSystemType, null)
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1.FullName, [])
+            .AssertOnlyViolations(helper);
+        should.NotHaveAttributeWithArguments(helper.Attribute1, []).AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1SystemType, [])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1Parameter3Value,
+                helper.Attribute1Parameter2Value
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1Parameter3Value, helper.Attribute1Parameter2Value]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1,
+                helper.Attribute1Parameter3Value,
+                helper.Attribute1Parameter2Value
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1,
+                [helper.Attribute1Parameter3Value, helper.Attribute1Parameter2Value]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1Parameter3Value,
+                helper.Attribute1Parameter2Value
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1Parameter3Value, helper.Attribute1Parameter2Value]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        should = Types().That().Are(helper.ClassWithArguments, helper.ClassWithAttributes).Should();
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1Parameter1Value
+            )
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1Parameter1Value]
+            )
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1, helper.Attribute1Parameter1Value)
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(helper.Attribute1, [helper.Attribute1Parameter1Value])
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1Parameter1Value
+            )
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAttributeWithArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1Parameter1Value]
+            )
+            .AssertAnyViolations(helper);
+
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotHaveAttributeWithNamedArgumentsTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations with type arguments");
+        var should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute2NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute2NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute2NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute2NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute2NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute2NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("No violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute2NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute2NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute2NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute2NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute2NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute2NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with type arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Violations with value arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Unused attribute");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.UnusedAttribute.FullName,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.UnusedAttribute.FullName,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.UnusedAttribute,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.UnusedAttribute,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.UnusedAttributeSystemType,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.UnusedAttributeSystemType,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Type outside of architecture");
+        should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should
+            .NotHaveAttributeWithNamedArguments(
+                typeof(TypeDependencyNamespace.BaseClass),
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithNamedArguments(helper.Attribute1.FullName, [])
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(helper.Attribute1, [])
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(helper.Attribute1SystemType, [])
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithArguments).Should();
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter1Pair,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter1Pair, helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter1Pair,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter1Pair, helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter1Pair,
+                helper.Attribute1NamedParameter2Pair
+            )
+            .AssertOnlyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter1Pair, helper.Attribute1NamedParameter2Pair]
+            )
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        should = Types().That().Are(helper.ClassWithArguments, helper.ClassWithAttributes).Should();
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1.FullName,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                helper.Attribute1NamedParameter1Pair
+            )
+            .AssertAnyViolations(helper);
+        should
+            .NotHaveAttributeWithNamedArguments(
+                helper.Attribute1SystemType,
+                [helper.Attribute1NamedParameter1Pair]
+            )
+            .AssertAnyViolations(helper);
+
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task NotHaveNameTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.BaseClass).Should();
+        should.NotHaveName(helper.BaseClass.FullName).AssertNoViolations(helper);
+        should.NotHaveName("^.*\\.Base.*$", true).AssertNoViolations(helper);
+        should.NotHaveFullName(helper.BaseClass.Name).AssertNoViolations(helper);
+        should.NotHaveFullName("^Base.*$", true).AssertNoViolations(helper);
+        should.NotHaveNameContaining(helper.BaseClass.Namespace.Name).AssertNoViolations(helper);
+        should.NotHaveFullNameContaining(helper.NonExistentObjectName).AssertNoViolations(helper);
+        should.NotHaveNameStartingWith(helper.BaseClass.Namespace.Name).AssertNoViolations(helper);
+        should.NotHaveNameEndingWith("Base").AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.BaseClass).Should();
+        should.NotHaveName(helper.BaseClass.Name).AssertOnlyViolations(helper);
+        should.NotHaveName("^Base.*$", true).AssertOnlyViolations(helper);
+        should.NotHaveFullName(helper.BaseClass.FullName).AssertOnlyViolations(helper);
+        should.NotHaveFullName("^.*\\.Base.*$", true).AssertOnlyViolations(helper);
+        should.NotHaveNameContaining("Base").AssertOnlyViolations(helper);
+        should
+            .NotHaveFullNameContaining(helper.BaseClass.Namespace.Name)
+            .AssertOnlyViolations(helper);
+        should.NotHaveNameStartingWith("Base").AssertOnlyViolations(helper);
+        should.NotHaveNameEndingWith("Class").AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task OnlyDependOnTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ChildClass).Should();
+        should.OnlyDependOn(helper.BaseClass.FullName).AssertNoViolations(helper);
+        should.OnlyDependOn("^.*\\.BaseClass$", true).AssertNoViolations(helper);
+        should.OnlyDependOn([helper.BaseClass.FullName]).AssertNoViolations(helper);
+        should.OnlyDependOn(["^.*\\.BaseClass$"], true).AssertNoViolations(helper);
+        should.OnlyDependOn(helper.BaseClass).AssertNoViolations(helper);
+        should.OnlyDependOn(helper.BaseClassSystemType).AssertNoViolations(helper);
+        should.OnlyDependOn(Classes().That().Are(helper.BaseClass)).AssertNoViolations(helper);
+        should.OnlyDependOn([helper.BaseClass]).AssertNoViolations(helper);
+        should.OnlyDependOn([helper.BaseClassSystemType]).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies).Should();
+        should.OnlyDependOn(helper.BaseClass.FullName).AssertOnlyViolations(helper);
+        should.OnlyDependOn([helper.BaseClass.FullName]).AssertOnlyViolations(helper);
+        should.OnlyDependOn(helper.BaseClass).AssertOnlyViolations(helper);
+        should.OnlyDependOn(helper.BaseClassSystemType).AssertOnlyViolations(helper);
+        should.OnlyDependOn(Classes().That().Are(helper.BaseClass)).AssertOnlyViolations(helper);
+        should.OnlyDependOn([helper.BaseClass]).AssertOnlyViolations(helper);
+        should.OnlyDependOn([helper.BaseClassSystemType]).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent type");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies).Should();
+        should.OnlyDependOn(helper.NonExistentObjectName).AssertOnlyViolations(helper);
+        should.OnlyDependOn([helper.NonExistentObjectName]).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Type outside of architecture");
+        should = Types().That().Are(helper.BaseClass).Should();
+        should
+            .OnlyDependOn(typeof(AttributeNamespace.ClassWithoutAttributes))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies).Should();
+        should.OnlyDependOn(new List<string>()).AssertOnlyViolations(helper);
+        should.OnlyDependOn(new List<IType>()).AssertOnlyViolations(helper);
+        should.OnlyDependOn(new List<System.Type>()).AssertOnlyViolations(helper);
+        should
+            .OnlyDependOn(Classes().That().Are(helper.NonExistentObjectName))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies).Should();
+        should
+            .OnlyDependOn([helper.BaseClass.FullName, helper.OtherBaseClass.FullName])
+            .AssertOnlyViolations(helper);
+        should.OnlyDependOn(helper.BaseClass, helper.OtherBaseClass).AssertOnlyViolations(helper);
+        should.OnlyDependOn([helper.BaseClass, helper.OtherBaseClass]).AssertOnlyViolations(helper);
+        should
+            .OnlyDependOn(helper.BaseClassSystemType, helper.OtherBaseClassSystemType)
+            .AssertOnlyViolations(helper);
+        should
+            .OnlyDependOn([helper.BaseClassSystemType, helper.OtherBaseClassSystemType])
+            .AssertOnlyViolations(helper);
+        should
+            .OnlyDependOn(Classes().That().Are(helper.BaseClass, helper.OtherBaseClass))
+            .AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task OnlyDependOnTypesThatTest()
+    {
+        var helper = new DependencyAssemblyTestHelper();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ChildClass).Should();
+        should.OnlyDependOnTypesThat().Are(helper.BaseClass.FullName).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ClassWithMultipleDependencies).Should();
+        should.OnlyDependOnTypesThat().Are(helper.BaseClass.FullName).AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task OnlyHaveAttributesTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should.OnlyHaveAttributes(helper.Attribute1.FullName).AssertNoViolations(helper);
+        should.OnlyHaveAttributes("^.*\\.Attribute1$", true).AssertNoViolations(helper);
+        should.OnlyHaveAttributes([helper.Attribute1.FullName]).AssertNoViolations(helper);
+        should.OnlyHaveAttributes(["^.*\\.Attribute1$"], true).AssertNoViolations(helper);
+        should.OnlyHaveAttributes(helper.Attribute1).AssertNoViolations(helper);
+        should.OnlyHaveAttributes([helper.Attribute1]).AssertNoViolations(helper);
+        should.OnlyHaveAttributes(helper.Attribute1SystemType).AssertNoViolations(helper);
+        should.OnlyHaveAttributes([helper.Attribute1SystemType]).AssertNoViolations(helper);
+        should
+            .OnlyHaveAttributes(Attributes().That().Are(helper.Attribute1))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should.OnlyHaveAttributes(helper.UnusedAttribute.FullName).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes([helper.UnusedAttribute.FullName]).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes(helper.UnusedAttribute).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes([helper.UnusedAttribute]).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes(helper.UnusedAttributeSystemType).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes([helper.UnusedAttributeSystemType]).AssertOnlyViolations(helper);
+        should
+            .OnlyHaveAttributes(Attributes().That().Are(helper.UnusedAttribute))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Non-existent attribute");
+        should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should.OnlyHaveAttributes(helper.NonExistentObjectName).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes([helper.NonExistentObjectName]).AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Attribute outside of architecture");
+        should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should
+            .OnlyHaveAttributes(typeof(TypeDependencyNamespace.BaseClass))
+            .AssertOnlyViolations(helper);
+
+        helper.AddSnapshotHeader("Empty arguments");
+        should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should.OnlyHaveAttributes(new List<string>()).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes(new List<Attribute>()).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes(new List<System.Type>()).AssertOnlyViolations(helper);
+        should
+            .OnlyHaveAttributes(Attributes().That().Are(helper.NonExistentObjectName))
+            .AssertOnlyViolations(helper);
+        should = Types().That().Are(helper.ClassWithoutAttributes).Should();
+        should.OnlyHaveAttributes(new List<string>()).AssertNoViolations(helper);
+        should.OnlyHaveAttributes(new List<Attribute>()).AssertNoViolations(helper);
+        should.OnlyHaveAttributes(new List<System.Type>()).AssertNoViolations(helper);
+        should
+            .OnlyHaveAttributes(Attributes().That().Are(helper.NonExistentObjectName))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple arguments");
+        should = Types().That().Are(helper.ClassWithAttributes).Should();
+        should
+            .OnlyHaveAttributes([helper.Attribute1.FullName, helper.Attribute2.FullName])
+            .AssertNoViolations(helper);
+        should.OnlyHaveAttributes(helper.Attribute1, helper.Attribute2).AssertNoViolations(helper);
+        should
+            .OnlyHaveAttributes([helper.Attribute1, helper.Attribute2])
+            .AssertNoViolations(helper);
+        should
+            .OnlyHaveAttributes(helper.Attribute1SystemType, helper.Attribute2SystemType)
+            .AssertNoViolations(helper);
+        should
+            .OnlyHaveAttributes([helper.Attribute1SystemType, helper.Attribute2SystemType])
+            .AssertNoViolations(helper);
+        should
+            .OnlyHaveAttributes(Attributes().That().Are(helper.Attribute1, helper.Attribute2))
+            .AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Multiple inputs");
+        should = Types()
+            .That()
+            .Are(helper.ClassWithAttributes, helper.OtherClassWithAttributes)
+            .Should();
+        should.OnlyHaveAttributes(helper.UnusedAttribute.FullName).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes([helper.UnusedAttribute.FullName]).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes(helper.UnusedAttribute).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes([helper.UnusedAttribute]).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes(helper.UnusedAttributeSystemType).AssertOnlyViolations(helper);
+        should.OnlyHaveAttributes([helper.UnusedAttributeSystemType]).AssertOnlyViolations(helper);
+        should
+            .OnlyHaveAttributes(Attributes().That().Are(helper.UnusedAttribute))
+            .AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public async Task OnlyHaveAttributesThatTest()
+    {
+        var helper = new AttributeAssemblyTestHelpers();
+        helper.AddSnapshotHeader("No violations");
+        var should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should.OnlyHaveAttributesThat().Are(helper.Attribute1.FullName).AssertNoViolations(helper);
+
+        helper.AddSnapshotHeader("Violations");
+        should = Types().That().Are(helper.ClassWithSingleAttribute).Should();
+        should
+            .OnlyHaveAttributesThat()
+            .Are(helper.UnusedAttribute.FullName)
+            .AssertOnlyViolations(helper);
+        await helper.AssertSnapshotMatches();
+    }
+
+    [Fact]
+    public void VisibilityTest()
+    {
+        var visibilityRules = new List<IArchRule>
+        {
+            Types().That().ArePrivate().Should().BePrivate(),
+            Types().That().ArePublic().Should().BePublic(),
+            Types().That().AreProtected().Should().BeProtected(),
+            Types().That().AreInternal().Should().BeInternal(),
+            Types().That().AreProtectedInternal().Should().BeProtectedInternal(),
+            Types().That().ArePrivateProtected().Should().BePrivateProtected(),
+            Types().That().AreNotPrivate().Should().NotBePrivate(),
+            Types().That().AreNotPublic().Should().NotBePublic(),
+            Types().That().AreNotProtected().Should().NotBeProtected(),
+            Types().That().AreNotInternal().Should().NotBeInternal(),
+            Types().That().AreNotProtectedInternal().Should().NotBeProtectedInternal(),
+            Types().That().AreNotPrivateProtected().Should().NotBePrivateProtected(),
+            Types()
+                .That()
+                .ArePrivate()
+                .Should()
+                .NotBePublic()
+                .AndShould()
+                .NotBeProtected()
+                .AndShould()
+                .NotBeInternal()
+                .AndShould()
+                .NotBeProtectedInternal()
+                .AndShould()
+                .NotBePrivateProtected(),
+            Types()
+                .That()
+                .ArePublic()
+                .Should()
+                .NotBePrivate()
+                .AndShould()
+                .NotBeProtected()
+                .AndShould()
+                .NotBeInternal()
+                .AndShould()
+                .NotBeProtectedInternal()
+                .AndShould()
+                .NotBePrivateProtected(),
+            Types()
+                .That()
+                .AreProtected()
+                .Should()
+                .NotBePublic()
+                .AndShould()
+                .NotBePrivate()
+                .AndShould()
+                .NotBeInternal()
+                .AndShould()
+                .NotBeProtectedInternal()
+                .AndShould()
+                .NotBePrivateProtected(),
+            Types()
+                .That()
+                .AreInternal()
+                .Should()
+                .NotBePublic()
+                .AndShould()
+                .NotBeProtected()
+                .AndShould()
+                .NotBePrivate()
+                .AndShould()
+                .NotBeProtectedInternal()
+                .AndShould()
+                .NotBePrivateProtected(),
+            Types()
+                .That()
+                .AreProtectedInternal()
+                .Should()
+                .NotBePublic()
+                .AndShould()
+                .NotBeProtected()
+                .AndShould()
+                .NotBeInternal()
+                .AndShould()
+                .NotBePrivate()
+                .AndShould()
+                .NotBePrivateProtected(),
+            Types()
+                .That()
+                .ArePrivateProtected()
+                .Should()
+                .NotBePublic()
+                .AndShould()
+                .NotBeProtected()
+                .AndShould()
+                .NotBeInternal()
+                .AndShould()
+                .NotBeProtectedInternal()
+                .AndShould()
+                .NotBePrivate(),
+            Types()
+                .That()
+                .AreNotPrivate()
+                .Should()
+                .BePublic()
+                .OrShould()
+                .BeProtected()
+                .OrShould()
+                .BeInternal()
+                .OrShould()
+                .BeProtectedInternal()
+                .OrShould()
+                .BePrivateProtected(),
+            Types()
+                .That()
+                .AreNotPublic()
+                .Should()
+                .BePrivate()
+                .OrShould()
+                .BeProtected()
+                .OrShould()
+                .BeInternal()
+                .OrShould()
+                .BeProtectedInternal()
+                .OrShould()
+                .BePrivateProtected(),
+            Types()
+                .That()
+                .AreNotProtected()
+                .Should()
+                .BePublic()
+                .OrShould()
+                .BePrivate()
+                .OrShould()
+                .BeInternal()
+                .OrShould()
+                .BeProtectedInternal()
+                .OrShould()
+                .BePrivateProtected(),
+            Types()
+                .That()
+                .AreNotInternal()
+                .Should()
+                .BePublic()
+                .OrShould()
+                .BeProtected()
+                .OrShould()
+                .BePrivate()
+                .OrShould()
+                .BeProtectedInternal()
+                .OrShould()
+                .BePrivateProtected(),
+            Types()
+                .That()
+                .AreNotProtectedInternal()
+                .Should()
+                .BePublic()
+                .OrShould()
+                .BeProtected()
+                .OrShould()
+                .BeInternal()
+                .OrShould()
+                .BePrivate()
+                .OrShould()
+                .BePrivateProtected(),
+            Types()
+                .That()
+                .AreNotPrivateProtected()
+                .Should()
+                .BePublic()
+                .OrShould()
+                .BeProtected()
+                .OrShould()
+                .BeInternal()
+                .OrShould()
+                .BeProtectedInternal()
+                .OrShould()
+                .BePrivate(),
+        };
+
+        foreach (var visibilityRule in visibilityRules)
+        {
+            Assert.True(
+                visibilityRule.HasNoViolations(StaticTestArchitectures.VisibilityArchitecture)
+            );
+        }
+    }
+}

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BeInternalTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BeInternalTest.verified.txt
@@ -1,0 +1,91 @@
+﻿===== No violations =====
+
+Query: Types that are "VisibilityNamespace.InternalClass" should be internal
+Result: True
+Description: VisibilityNamespace.InternalClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be internal
+Result: True
+Description: VisibilityNamespace.OuterClass+InternalInnerClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "VisibilityNamespace.PublicClass" should be internal
+Result: False
+Description: VisibilityNamespace.PublicClass is public
+Message: 
+"Types that are "VisibilityNamespace.PublicClass" should be internal" failed:
+	VisibilityNamespace.PublicClass is public
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be internal
+Result: False
+Description: VisibilityNamespace.OuterClass+PublicInnerClass is public
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be internal" failed:
+	VisibilityNamespace.OuterClass+PublicInnerClass is public
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be internal
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInnerClass is protected
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be internal" failed:
+	VisibilityNamespace.OuterClass+ProtectedInnerClass is protected
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be internal
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be internal" failed:
+	VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be internal
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateInnerClass is private
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be internal" failed:
+	VisibilityNamespace.OuterClass+PrivateInnerClass is private
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be internal
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be internal" failed:
+	VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "VisibilityNamespace.InternalClass" or "VisibilityNamespace.OtherInternalClass" should be internal
+Result: True
+Description: VisibilityNamespace.InternalClass passed
+Result: True
+Description: VisibilityNamespace.OtherInternalClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "VisibilityNamespace.InternalClass" or "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be internal
+Result: True
+Description: VisibilityNamespace.InternalClass passed
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+Message: 
+"Types that are "VisibilityNamespace.InternalClass" or "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be internal" failed:
+	VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BePrivateProtectedTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BePrivateProtectedTest.verified.txt
@@ -1,0 +1,94 @@
+﻿===== No violations =====
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be private protected
+Result: True
+Description: VisibilityNamespace.OuterClass+PrivateProtectedInnerClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "VisibilityNamespace.PublicClass" should be private protected
+Result: False
+Description: VisibilityNamespace.PublicClass is public
+Message: 
+"Types that are "VisibilityNamespace.PublicClass" should be private protected" failed:
+	VisibilityNamespace.PublicClass is public
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be private protected
+Result: False
+Description: VisibilityNamespace.OuterClass+PublicInnerClass is public
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be private protected" failed:
+	VisibilityNamespace.OuterClass+PublicInnerClass is public
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be private protected
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInnerClass is protected
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be private protected" failed:
+	VisibilityNamespace.OuterClass+ProtectedInnerClass is protected
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be private protected
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be private protected" failed:
+	VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+
+
+
+Query: Types that are "VisibilityNamespace.InternalClass" should be private protected
+Result: False
+Description: VisibilityNamespace.InternalClass is internal
+Message: 
+"Types that are "VisibilityNamespace.InternalClass" should be private protected" failed:
+	VisibilityNamespace.InternalClass is internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be private protected
+Result: False
+Description: VisibilityNamespace.OuterClass+InternalInnerClass is internal
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be private protected" failed:
+	VisibilityNamespace.OuterClass+InternalInnerClass is internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be private protected
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateInnerClass is private
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be private protected" failed:
+	VisibilityNamespace.OuterClass+PrivateInnerClass is private
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" or "VisibilityNamespace.OuterClass+OtherPrivateProtectedInnerClass" should be private protected
+Result: True
+Description: VisibilityNamespace.OuterClass+PrivateProtectedInnerClass passed
+Result: True
+Description: VisibilityNamespace.OuterClass+OtherPrivateProtectedInnerClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" or "VisibilityNamespace.OuterClass+PrivateInnerClass" should be private protected
+Result: True
+Description: VisibilityNamespace.OuterClass+PrivateProtectedInnerClass passed
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateInnerClass is private
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" or "VisibilityNamespace.OuterClass+PrivateInnerClass" should be private protected" failed:
+	VisibilityNamespace.OuterClass+PrivateInnerClass is private
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BePrivateTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BePrivateTest.verified.txt
@@ -1,0 +1,94 @@
+﻿===== No violations =====
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be private
+Result: True
+Description: VisibilityNamespace.OuterClass+PrivateInnerClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "VisibilityNamespace.PublicClass" should be private
+Result: False
+Description: VisibilityNamespace.PublicClass is public
+Message: 
+"Types that are "VisibilityNamespace.PublicClass" should be private" failed:
+	VisibilityNamespace.PublicClass is public
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be private
+Result: False
+Description: VisibilityNamespace.OuterClass+PublicInnerClass is public
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be private" failed:
+	VisibilityNamespace.OuterClass+PublicInnerClass is public
+
+
+
+Query: Types that are "VisibilityNamespace.InternalClass" should be private
+Result: False
+Description: VisibilityNamespace.InternalClass is internal
+Message: 
+"Types that are "VisibilityNamespace.InternalClass" should be private" failed:
+	VisibilityNamespace.InternalClass is internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be private
+Result: False
+Description: VisibilityNamespace.OuterClass+InternalInnerClass is internal
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be private" failed:
+	VisibilityNamespace.OuterClass+InternalInnerClass is internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be private
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInnerClass is protected
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be private" failed:
+	VisibilityNamespace.OuterClass+ProtectedInnerClass is protected
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be private
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be private" failed:
+	VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be private
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be private" failed:
+	VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" or "VisibilityNamespace.OuterClass+OtherPrivateInnerClass" should be private
+Result: True
+Description: VisibilityNamespace.OuterClass+PrivateInnerClass passed
+Result: True
+Description: VisibilityNamespace.OuterClass+OtherPrivateInnerClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" or "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be private
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+Result: True
+Description: VisibilityNamespace.OuterClass+PrivateInnerClass passed
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" or "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be private" failed:
+	VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BeProtectedInternalTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BeProtectedInternalTest.verified.txt
@@ -1,0 +1,94 @@
+﻿===== No violations =====
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be protected internal
+Result: True
+Description: VisibilityNamespace.OuterClass+ProtectedInternalInnerClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "VisibilityNamespace.PublicClass" should be protected internal
+Result: False
+Description: VisibilityNamespace.PublicClass is public
+Message: 
+"Types that are "VisibilityNamespace.PublicClass" should be protected internal" failed:
+	VisibilityNamespace.PublicClass is public
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be protected internal
+Result: False
+Description: VisibilityNamespace.OuterClass+PublicInnerClass is public
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be protected internal" failed:
+	VisibilityNamespace.OuterClass+PublicInnerClass is public
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be protected internal
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInnerClass is protected
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be protected internal" failed:
+	VisibilityNamespace.OuterClass+ProtectedInnerClass is protected
+
+
+
+Query: Types that are "VisibilityNamespace.InternalClass" should be protected internal
+Result: False
+Description: VisibilityNamespace.InternalClass is internal
+Message: 
+"Types that are "VisibilityNamespace.InternalClass" should be protected internal" failed:
+	VisibilityNamespace.InternalClass is internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be protected internal
+Result: False
+Description: VisibilityNamespace.OuterClass+InternalInnerClass is internal
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be protected internal" failed:
+	VisibilityNamespace.OuterClass+InternalInnerClass is internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be protected internal
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateInnerClass is private
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be protected internal" failed:
+	VisibilityNamespace.OuterClass+PrivateInnerClass is private
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be protected internal
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be protected internal" failed:
+	VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" or "VisibilityNamespace.OuterClass+OtherProtectedInternalInnerClass" should be protected internal
+Result: True
+Description: VisibilityNamespace.OuterClass+ProtectedInternalInnerClass passed
+Result: True
+Description: VisibilityNamespace.OuterClass+OtherProtectedInternalInnerClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" or "VisibilityNamespace.InternalClass" should be protected internal
+Result: False
+Description: VisibilityNamespace.InternalClass is internal
+Result: True
+Description: VisibilityNamespace.OuterClass+ProtectedInternalInnerClass passed
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" or "VisibilityNamespace.InternalClass" should be protected internal" failed:
+	VisibilityNamespace.InternalClass is internal
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BeProtectedTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BeProtectedTest.verified.txt
@@ -1,0 +1,94 @@
+﻿===== No violations =====
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be protected
+Result: True
+Description: VisibilityNamespace.OuterClass+ProtectedInnerClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "VisibilityNamespace.PublicClass" should be protected
+Result: False
+Description: VisibilityNamespace.PublicClass is public
+Message: 
+"Types that are "VisibilityNamespace.PublicClass" should be protected" failed:
+	VisibilityNamespace.PublicClass is public
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be protected
+Result: False
+Description: VisibilityNamespace.OuterClass+PublicInnerClass is public
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be protected" failed:
+	VisibilityNamespace.OuterClass+PublicInnerClass is public
+
+
+
+Query: Types that are "VisibilityNamespace.InternalClass" should be protected
+Result: False
+Description: VisibilityNamespace.InternalClass is internal
+Message: 
+"Types that are "VisibilityNamespace.InternalClass" should be protected" failed:
+	VisibilityNamespace.InternalClass is internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be protected
+Result: False
+Description: VisibilityNamespace.OuterClass+InternalInnerClass is internal
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be protected" failed:
+	VisibilityNamespace.OuterClass+InternalInnerClass is internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be protected
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateInnerClass is private
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be protected" failed:
+	VisibilityNamespace.OuterClass+PrivateInnerClass is private
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be protected
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be protected" failed:
+	VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be protected
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be protected" failed:
+	VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" or "VisibilityNamespace.OuterClass+OtherProtectedInnerClass" should be protected
+Result: True
+Description: VisibilityNamespace.OuterClass+ProtectedInnerClass passed
+Result: True
+Description: VisibilityNamespace.OuterClass+OtherProtectedInnerClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" or "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be protected
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+Result: True
+Description: VisibilityNamespace.OuterClass+ProtectedInnerClass passed
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" or "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be protected" failed:
+	VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BePublicTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BePublicTest.verified.txt
@@ -1,0 +1,91 @@
+﻿===== No violations =====
+
+Query: Types that are "VisibilityNamespace.PublicClass" should be public
+Result: True
+Description: VisibilityNamespace.PublicClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "VisibilityNamespace.OuterClass+PublicInnerClass" should be public
+Result: True
+Description: VisibilityNamespace.OuterClass+PublicInnerClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "VisibilityNamespace.InternalClass" should be public
+Result: False
+Description: VisibilityNamespace.InternalClass is internal
+Message: 
+"Types that are "VisibilityNamespace.InternalClass" should be public" failed:
+	VisibilityNamespace.InternalClass is internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be public
+Result: False
+Description: VisibilityNamespace.OuterClass+InternalInnerClass is internal
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+InternalInnerClass" should be public" failed:
+	VisibilityNamespace.OuterClass+InternalInnerClass is internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be public
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInnerClass is protected
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInnerClass" should be public" failed:
+	VisibilityNamespace.OuterClass+ProtectedInnerClass is protected
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be public
+Result: False
+Description: VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+ProtectedInternalInnerClass" should be public" failed:
+	VisibilityNamespace.OuterClass+ProtectedInternalInnerClass is protected internal
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be public
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateInnerClass is private
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateInnerClass" should be public" failed:
+	VisibilityNamespace.OuterClass+PrivateInnerClass is private
+
+
+
+Query: Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be public
+Result: False
+Description: VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+Message: 
+"Types that are "VisibilityNamespace.OuterClass+PrivateProtectedInnerClass" should be public" failed:
+	VisibilityNamespace.OuterClass+PrivateProtectedInnerClass is private protected
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "VisibilityNamespace.PublicClass" or "VisibilityNamespace.OtherPublicClass" should be public
+Result: True
+Description: VisibilityNamespace.PublicClass passed
+Result: True
+Description: VisibilityNamespace.OtherPublicClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "VisibilityNamespace.PublicClass" or "VisibilityNamespace.InternalClass" should be public
+Result: True
+Description: VisibilityNamespace.PublicClass passed
+Result: False
+Description: VisibilityNamespace.InternalClass is internal
+Message: 
+"Types that are "VisibilityNamespace.PublicClass" or "VisibilityNamespace.InternalClass" should be public" failed:
+	VisibilityNamespace.InternalClass is internal
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BeTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.BeTest.verified.txt
@@ -1,0 +1,265 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should have full name "TypeDependencyNamespace.ChildClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should have full name matching "^.*\.ChildClass$"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should have full name "TypeDependencyNamespace.ChildClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should have full name matching "^.*\.ChildClass$"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ChildClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ChildClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be Classes that are "TypeDependencyNamespace.ChildClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ChildClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ChildClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should have full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does not have full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should have full name "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ChildClass does not have full name "TypeDependencyNamespace.ClassWithoutDependencies"
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should have full name matching "^.*\.ClassWithoutDependencies$"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does not have full name matching "^.*\.ClassWithoutDependencies$"
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should have full name matching "^.*\.ClassWithoutDependencies$"" failed:
+	TypeDependencyNamespace.ChildClass does not have full name matching "^.*\.ClassWithoutDependencies$"
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should have full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does not have full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should have full name "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ChildClass does not have full name "TypeDependencyNamespace.ClassWithoutDependencies"
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should have full name matching "^.*\.ClassWithoutDependencies$"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does not have full name matching "^.*\.ClassWithoutDependencies$"
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should have full name matching "^.*\.ClassWithoutDependencies$"" failed:
+	TypeDependencyNamespace.ChildClass does not have full name matching "^.*\.ClassWithoutDependencies$"
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is not "TypeDependencyNamespace.ClassWithoutDependencies"
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ChildClass is not "TypeDependencyNamespace.ClassWithoutDependencies"
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be Classes that are "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is not Classes that are "TypeDependencyNamespace.ClassWithoutDependencies"
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should be Classes that are "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ChildClass is not Classes that are "TypeDependencyNamespace.ClassWithoutDependencies"
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is not "TypeDependencyNamespace.ClassWithoutDependencies"
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ChildClass is not "TypeDependencyNamespace.ClassWithoutDependencies"
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+
+
+
+===== Non-existent type =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name "NotTheNameOfAnyObject"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does not have full name "NotTheNameOfAnyObject"
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should have full name "NotTheNameOfAnyObject"" failed:
+	TypeDependencyNamespace.BaseClass does not have full name "NotTheNameOfAnyObject"
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name "NotTheNameOfAnyObject"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does not have full name "NotTheNameOfAnyObject"
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should have full name "NotTheNameOfAnyObject"" failed:
+	TypeDependencyNamespace.BaseClass does not have full name "NotTheNameOfAnyObject"
+
+
+
+===== Empty arguments =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not exist
+Result: False
+Description: TypeDependencyNamespace.BaseClass does exist
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not exist" failed:
+	TypeDependencyNamespace.BaseClass does exist
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not exist
+Result: False
+Description: TypeDependencyNamespace.BaseClass does exist
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not exist" failed:
+	TypeDependencyNamespace.BaseClass does exist
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not exist
+Result: False
+Description: TypeDependencyNamespace.BaseClass is TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not exist" failed:
+	TypeDependencyNamespace.BaseClass is TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should be Classes that have full name "NotTheNameOfAnyObject"
+Result: False
+Description: TypeDependencyNamespace.BaseClass is not Classes that have full name "NotTheNameOfAnyObject"
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should be Classes that have full name "NotTheNameOfAnyObject"" failed:
+	TypeDependencyNamespace.BaseClass is not Classes that have full name "NotTheNameOfAnyObject"
+
+
+
+===== Multiple arguments =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should have full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does not have full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should have full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does not have full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is not "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass is not "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is not "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass is not "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" or "TypeDependencyNamespace.BaseClass" should be "TypeDependencyNamespace.ChildClass" or "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" or "TypeDependencyNamespace.BaseClass" should be "TypeDependencyNamespace.ChildClass" or "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.BaseClass is not "TypeDependencyNamespace.ChildClass" or "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" or "TypeDependencyNamespace.BaseClass" should be "TypeDependencyNamespace.ChildClass" or "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.BaseClass is not "TypeDependencyNamespace.ChildClass" or "TypeDependencyNamespace.ClassWithoutDependencies"
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.CallAnyTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.CallAnyTest.verified.txt
@@ -176,7 +176,7 @@ Message:
 
 
 
-===== Multiple inputs =====
+===== Input with multiple dependencies =====
 
 Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1()" or "System.Void MethodDependencyNamespace.MethodDependencyClass...
 Result: True

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.CallAnyTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.CallAnyTest.verified.txt
@@ -1,0 +1,195 @@
+﻿===== No violations =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name matching "^.*::CalledMethod\(\)$"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name matching "^.*::CalledMethod\(\)$"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call any Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does not call any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does not call any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does not call any methods with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does not call any methods with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call any Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call any Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+
+
+
+===== Non-existent method member =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name "NotTheNameOfAnyObject"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does not call any method with full name "NotTheNameOfAnyObject"
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name "NotTheNameOfAnyObject"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does not call any method with full name "NotTheNameOfAnyObject"
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name "NotTheNameOfAnyObject"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does not call any methods with full name "NotTheNameOfAnyObject"
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should calls any method with full name "NotTheNameOfAnyObject"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does not call any methods with full name "NotTheNameOfAnyObject"
+
+
+
+===== Empty arguments =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call one of no methods (impossible)
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does not call one of no methods (always true)
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call one of no methods (impossible)" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does not call one of no methods (always true)
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call one of no methods (impossible)
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call one of no methods (impossible)" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call any Method members that have full name "NotTheNameOfAnyObject"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should call any Method members that have full name "NotTheNameOfAnyObject"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+
+
+
+===== Multiple arguments =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should calls any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDe...
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does not call any methods with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()"
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should calls any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDe..." failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does not call any methods with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()"
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDependencyNamespace.MethodDep...
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod3()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDependencyNamespace.MethodDep..." failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod3()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDependencyNamespace.MethodDep...
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod3()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDependencyNamespace.MethodDep..." failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod3()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should call any Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodD...
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod3()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should call any Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodD..." failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod3()
+
+
+
+===== Multiple inputs =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1()" or "System.Void MethodDependencyNamespace.MethodDependencyClass...
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod3()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod3()
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.DependOnAnyTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.DependOnAnyTest.verified.txt
@@ -1,0 +1,270 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should depend on any types with full name "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should depend on any types with full name matching "^.*\.BaseClass$"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should depend on any types with full name "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should depend on any types with full name matching "^.*\.BaseClass$"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should depend on "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should depend on "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should depend on any Classes that are "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should depend on "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should depend on "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any types with full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does not depend on any type with full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any types with full name "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does not depend on any type with full name "TypeDependencyNamespace.ClassWithoutDependencies"
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any types with full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does not depend any types with full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any types with full name "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does not depend any types with full name "TypeDependencyNamespace.ClassWithoutDependencies"
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any Classes that are "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any Classes that are "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+===== Non-existent type =====
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any types with full name "NotTheNameOfAnyObject"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does not depend on any type with full name "NotTheNameOfAnyObject"
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any types with full name "NotTheNameOfAnyObject"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does not depend on any type with full name "NotTheNameOfAnyObject"
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any types with full name "NotTheNameOfAnyObject"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does not depend any types with full name "NotTheNameOfAnyObject"
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any types with full name "NotTheNameOfAnyObject"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does not depend any types with full name "NotTheNameOfAnyObject"
+
+
+
+===== Type outside of architecture =====
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "AttributeNamespace.ClassWithoutAttributes"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "AttributeNamespace.ClassWithoutAttributes"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+===== Empty arguments =====
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on one of no types (impossible)
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does not depend on no types (always true)
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on one of no types (impossible)" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does not depend on no types (always true)
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on one of no types (impossible)
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on one of no types (impossible)" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on one of no types (impossible)
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on one of no types (impossible)" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any Classes that have full name "NotTheNameOfAnyObject"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any Classes that have full name "NotTheNameOfAnyObject"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+===== Multiple arguments =====
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any types with full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does not depend any types with full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any types with full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does not depend any types with full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+===== Input without dependencies =====
+
+Query: Types that are "TypeDependencyNamespace.ClassWithoutDependencies" should depend on any types with full name "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.ChildClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithoutDependencies does not depend any types with full name "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.ChildClass"
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithoutDependencies" should depend on any types with full name "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.ChildClass"" failed:
+	TypeDependencyNamespace.ClassWithoutDependencies does not depend any types with full name "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.ChildClass"
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass1" or "TypeDependencyNamespace.ChildClass2" should depend on "TypeDependencyNamespace.BaseClassWithMultipleDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass1 passed
+Result: True
+Description: TypeDependencyNamespace.ChildClass2 passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" or "TypeDependencyNamespace.BaseClass" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does depend on System.Object
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" or "TypeDependencyNamespace.BaseClass" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
+	TypeDependencyNamespace.BaseClass does depend on System.Object
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.DependOnAnyTypesThatTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.DependOnAnyTypesThatTest.verified.txt
@@ -1,0 +1,19 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should depend on any types that are "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should depend on any types that are "TypeDependencyNamespace.ChildClass"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does depend on System.Object
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should depend on any types that are "TypeDependencyNamespace.ChildClass"" failed:
+	TypeDependencyNamespace.BaseClass does depend on System.Object
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.ExistTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.ExistTest.verified.txt
@@ -1,0 +1,25 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should exist
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should exist
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that have full name "NotTheNameOfAnyObject" should exist
+Result: False
+Description: There are no objects matching the criteria
+Message: 
+"Types that have full name "NotTheNameOfAnyObject" should exist" failed:
+	There are no objects matching the criteria
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.FollowCustomConditionTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.FollowCustomConditionTest.verified.txt
@@ -1,0 +1,49 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should follow custom condition
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should follow custom condition
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should follow custom condition
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should follow custom condition
+Result: False
+Description: TypeDependencyNamespace.BaseClass does not follow custom condition
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should follow custom condition" failed:
+	TypeDependencyNamespace.BaseClass does not follow custom condition
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should follow custom condition
+Result: False
+Description: TypeDependencyNamespace.BaseClass does not follow custom condition
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should follow custom condition" failed:
+	TypeDependencyNamespace.BaseClass does not follow custom condition
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should follow custom condition
+Result: False
+Description: TypeDependencyNamespace.BaseClass does not follow custom condition
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should follow custom condition" failed:
+	TypeDependencyNamespace.BaseClass does not follow custom condition
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAnyAttributesTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAnyAttributesTest.verified.txt
@@ -1,0 +1,238 @@
+﻿===== No violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name matching "^.*\.Attribute1$"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name matching "^.*\.Attribute1$"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any Attributes that are "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have any attribute with full name "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does not have any attribute with full name "AttributeNamespace.UnusedAttribute"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have any attribute with full name "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does not have any attribute with full name "AttributeNamespace.UnusedAttribute"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.UnusedAttribute"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.UnusedAttribute"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.UnusedAttribute"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.UnusedAttribute"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any Attributes that are "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have any Attributes that are "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have any Attributes that are "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does not have any Attributes that are "AttributeNamespace.UnusedAttribute"
+
+
+
+===== Non-existent attribute =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "NotTheNameOfAnyObject"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have any attribute with full name "NotTheNameOfAnyObject"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "NotTheNameOfAnyObject"" failed:
+	AttributeNamespace.ClassWithAttributes does not have any attribute with full name "NotTheNameOfAnyObject"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "NotTheNameOfAnyObject"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have any attribute with full name "NotTheNameOfAnyObject"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "NotTheNameOfAnyObject"" failed:
+	AttributeNamespace.ClassWithAttributes does not have any attribute with full name "NotTheNameOfAnyObject"
+
+
+
+===== Empty arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have one of no attributes (impossible)
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have one of no attributes (always true)
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have one of no attributes (impossible)" failed:
+	AttributeNamespace.ClassWithAttributes does not have one of no attributes (always true)
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have one of no attributes (impossible)
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have one of no attributes (always true)
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have one of no attributes (impossible)" failed:
+	AttributeNamespace.ClassWithAttributes does not have one of no attributes (always true)
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have one of no attributes (impossible)
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have one of no attributes (always true)
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have one of no attributes (impossible)" failed:
+	AttributeNamespace.ClassWithAttributes does not have one of no attributes (always true)
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any Attributes that have full name "NotTheNameOfAnyObject"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have any Attributes that have full name "NotTheNameOfAnyObject"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have any Attributes that have full name "NotTheNameOfAnyObject"" failed:
+	AttributeNamespace.ClassWithAttributes does not have any Attributes that have full name "NotTheNameOfAnyObject"
+
+
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any attribute with full name "AttributeNamespace.Attribute1" or "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have any Attributes that are "AttributeNamespace.Attribute1" or "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: True
+Description: AttributeNamespace.OtherClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.ClassWithoutAttributes" should have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithoutAttributes does not have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.ClassWithoutAttributes" should have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithoutAttributes does not have attribute "AttributeNamespace.Attribute1"
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAnyAttributesThatTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAnyAttributesThatTest.verified.txt
@@ -1,0 +1,19 @@
+﻿===== No violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attributes that are "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have attributes that are "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should have attributes that are "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.UnusedAttribute"
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAnyAttributesWithArgumentsTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAnyAttributesWithArgumentsTest.verified.txt
@@ -1,0 +1,134 @@
+﻿===== No violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "AttributeNamespace.TypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "AttributeNamespace.TypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== No violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "AttributeNamespace.UnusedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "AttributeNamespace.UnusedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "AttributeNamespace.UnusedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "AttributeNamespace.UnusedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should have any attributes with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithoutAttributes does have no attribute with an argument
+Message: 
+"Types that are "AttributeNamespace.ClassWithoutAttributes" should have any attributes with arguments "0"" failed:
+	AttributeNamespace.ClassWithoutAttributes does have no attribute with an argument
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should have any attributes with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithoutAttributes does have no attribute with an argument
+Message: 
+"Types that are "AttributeNamespace.ClassWithoutAttributes" should have any attributes with arguments "0"" failed:
+	AttributeNamespace.ClassWithoutAttributes does have no attribute with an argument
+
+
+
+===== Null argument =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments ""
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments """ failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Empty arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have no or any attributes with arguments (always true)
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should have no or any attributes with arguments (always true)
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "AttributeNamespace.OtherTypeArgument" and "UnusedValueArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "AttributeNamespace.OtherTypeArgument" and "UnusedValueArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "AttributeNamespace.OtherTypeArgument" and "UnusedValueArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with arguments "AttributeNamespace.OtherTypeArgument" and "UnusedValueArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.OtherClassWithArguments" should have any attributes with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Result: True
+Description: AttributeNamespace.OtherClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have any attributes with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attributes with argument values "" and "" and "-1" and "" and "" and "" and "-1"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have any attributes with arguments "0"" failed:
+	AttributeNamespace.ClassWithAttributes does have attributes with argument values "" and "" and "-1" and "" and "" and "" and "-1"
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAnyAttributesWithNamedArguments.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAnyAttributesWithNamedArguments.verified.txt
@@ -1,0 +1,168 @@
+﻿===== No violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== No violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "OtherNamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "OtherNamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "OtherNamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "OtherNamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter2=OtherNamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter2=OtherNamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter2=OtherNamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter2=OtherNamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Empty arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have no or any attributes with named arguments (always true)
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=OtherNamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=OtherNamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=OtherNamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=OtherNamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have no attribute with a named argument
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithAttributes does have no attribute with a named argument
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have no attribute with a named argument
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithAttributes does have no attribute with a named argument
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAttributeWithArgumentsTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAttributeWithArgumentsTest.verified.txt
@@ -1,0 +1,312 @@
+﻿===== No violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== No violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+
+
+
+===== Violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments "OtherArgument"
+
+
+
+===== Non-existent attribute =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "NotTheNameOfAnyObject" with arguments "Argument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "NotTheNameOfAnyObject" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "NotTheNameOfAnyObject" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "NotTheNameOfAnyObject" with arguments "Argument"
+
+
+
+===== Type outside of architecture =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "TypeDependencyNamespace.BaseClass" with arguments "Argument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "TypeDependencyNamespace.BaseClass" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "TypeDependencyNamespace.BaseClass" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "TypeDependencyNamespace.BaseClass" with arguments "Argument"
+
+
+
+===== Null argument =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments ""
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments ""
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments """ failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments ""
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments ""
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments ""
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments """ failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments ""
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments ""
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments ""
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments """ failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with arguments ""
+
+
+
+===== Empty arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument" and "0"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument" and "0"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument" and "0"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument" and "0"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument" and "0"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.OtherClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Result: True
+Description: AttributeNamespace.OtherClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with arguments "0"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAttributeWithNamedArguments.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveAttributeWithNamedArguments.verified.txt
@@ -1,0 +1,507 @@
+﻿===== No violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== No violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+
+
+
+===== Violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=OtherNamedArgument"
+
+
+
+===== Unused attribute =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+===== Type outside of architecture =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "TypeDependencyNamespace.BaseClass" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "TypeDependencyNamespace.BaseClass" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "TypeDependencyNamespace.BaseClass" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "TypeDependencyNamespace.BaseClass" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+===== Emtpy arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "OtherNamedParameter2=3"
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithAttributes does not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveNameTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.HaveNameTest.verified.txt
@@ -1,0 +1,124 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name "BaseClass"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name matching "^Base.*$"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name matching "^.*\.Base.*$"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have name containing "Base"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name containing "TypeDependencyNamespace"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have name starting with "Base"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have name ending with "Class"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have name BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should have full name "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.BaseClass does have name BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name "^.*\.Base.*$"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have name BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should have full name "^.*\.Base.*$"" failed:
+	TypeDependencyNamespace.BaseClass does have name BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name "BaseClass"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should have full name "BaseClass"" failed:
+	TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name "^Base.*$"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should have full name "^Base.*$"" failed:
+	TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have name containing "TypeDependencyNamespace"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have name BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should have name containing "TypeDependencyNamespace"" failed:
+	TypeDependencyNamespace.BaseClass does have name BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have full name containing "NotTheNameOfAnyObject"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should have full name containing "NotTheNameOfAnyObject"" failed:
+	TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have name starting with "TypeDependencyNamespace"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have name BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should have name starting with "TypeDependencyNamespace"" failed:
+	TypeDependencyNamespace.BaseClass does have name BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should have name ending with "Base"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have name BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should have name ending with "Base"" failed:
+	TypeDependencyNamespace.BaseClass does have name BaseClass
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotBeTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotBeTest.verified.txt
@@ -1,0 +1,247 @@
+﻿===== No violations =====
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name matching "^.*\.ClassWithoutDependencies$"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name matching "^.*\.ClassWithoutDependencies$"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be Classes that are "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name "TypeDependencyNamespace.ChildClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+"Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name "TypeDependencyNamespace.ChildClass"" failed:
+	TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+
+
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name "TypeDependencyNamespace.ChildClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+"Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name "TypeDependencyNamespace.ChildClass"" failed:
+	TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+
+
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ChildClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+"Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ChildClass"" failed:
+	TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+
+
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ChildClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+"Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ChildClass"" failed:
+	TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+
+
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be Classes that are "TypeDependencyNamespace.ChildClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is Classes that are "TypeDependencyNamespace.ChildClass"
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+"Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be Classes that are "TypeDependencyNamespace.ChildClass"" failed:
+	TypeDependencyNamespace.ChildClass is Classes that are "TypeDependencyNamespace.ChildClass"
+
+
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ChildClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+"Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ChildClass"" failed:
+	TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+
+
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ChildClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+"Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ChildClass"" failed:
+	TypeDependencyNamespace.ChildClass is TypeDependencyNamespace.ChildClass
+
+
+
+===== Non-existent type =====
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name "NotTheNameOfAnyObject"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name "NotTheNameOfAnyObject"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+===== Empty arguments =====
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should exist
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should exist
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be no type (always true)
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be Classes that have full name "NotTheNameOfAnyObject"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not have full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that depend on any types with full name "TypeDependencyNamespace.BaseClass" should not be "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Result: True
+Description: TypeDependencyNamespace.OtherChildClass passed
+Message: 
+All Evaluations passed
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotCallAnyTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotCallAnyTest.verified.txt
@@ -1,0 +1,194 @@
+﻿===== No violations =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call any method with full name matching "^.*\.MethodWithoutDependencies$"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call methods with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call any method with full name matching "^.*\.MethodWithoutDependencies$"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call any method with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call methods with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call methods with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+
+
+
+===== Non-existent method member =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call any method with full name "NotTheNameOfAnyObject"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call methods with full name "NotTheNameOfAnyObject"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+===== Empty arguments =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call no methods (always true)
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call no methods (always true)
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" should not call Method members that have full name "NotTheNameOfAnyObject"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should not call any method with full name matching "^.*::(MethodWithoutDependencies|CalledMethod[0-9])\(\)$"
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod3()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should not call any method with full name matching "^.*::(MethodWithoutDependencies|CalledMethod[0-9])\(\)$"" failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod3()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should not call methods with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDe...
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should not call methods with full name "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDe..." failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDependencyNamespace.Metho...
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDependencyNamespace.Metho..." failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDependencyNamespace.Metho...
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodDependencyNamespace.Metho..." failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2()
+
+
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should not call Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodD...
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies()" should not call Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()" or "System.Void MethodD..." failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2()
+
+
+
+===== Multiple inputs =====
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" or "System.Void MethodDependencyNamespace.MethodDep... should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithoutDependencies()"
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() passed
+Result: True
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() passed
+Message: 
+All Evaluations passed
+
+Query: Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" or "System.Void MethodDependencyNamespace.MethodDep... should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()" or "System.Void MethodDependencyNamespace.MethodDependencyCl...
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+Result: False
+Description: System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2()
+Message: 
+"Method members that are "System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency()" or "System.Void MethodDependencyNamespace.MethodDep... should not call "System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()" or "System.Void MethodDependencyNamespace.MethodDependencyCl..." failed:
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithSingleDependency() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod()
+	System.Void MethodDependencyNamespace.MethodDependencyClass::MethodWithMultipleDependencies() does call System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod1() and System.Void MethodDependencyNamespace.MethodDependencyClass::CalledMethod2()
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotDependOnAnyTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotDependOnAnyTest.verified.txt
@@ -1,0 +1,281 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on any types with full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on any types with full name matching "^.*\.ClassWithoutDependencies$"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on types with full name "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on any types with full name matching "^.*\.ClassWithoutDependencies$"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on Classes that are "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on any types with full name "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass and TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on any types with full name "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass and TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on types with full name "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass and TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on types with full name "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass and TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on Classes that are "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on Classes that are "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+
+===== Non-existent type =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on any types with full name "NotTheNameOfAnyObject"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on types with full name "NotTheNameOfAnyObject"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+===== Type outside of architecture =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "AttributeNamespace.ClassWithoutAttributes"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+===== Empty arguments =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on no types (always true)
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on no types (always true)
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on no types (always true)
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on Classes that have full name "NotTheNameOfAnyObject"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on types with full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass and TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on types with full name "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass and TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+
+===== Input with multiple dependencies =====
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on any types with full name matching "^.*\.(BaseClassWithMember|OtherBaseClass)$"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on any types with full name matching "^.*\.(BaseClassWithMember|OtherBaseClass)$"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on types with full name "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on types with full name "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on Classes that are "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should not depend on Classes that are "TypeDependencyNamespace.BaseClassWithMember" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotDependOnAnyTypesThatTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotDependOnAnyTypesThatTest.verified.txt
@@ -1,0 +1,19 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not depend on any types that are "TypeDependencyNamespace.ChildClass"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should not depend on any types that are "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ChildClass" should not depend on any types that are "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ChildClass does depend on TypeDependencyNamespace.BaseClass
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotExistTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotExistTest.verified.txt
@@ -1,0 +1,20 @@
+﻿===== No violations =====
+
+Query: Types that depend on "TypeDependencyNamespace.ChildClass" should not exist
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that depend on "TypeDependencyNamespace.BaseClass" should not exist
+Result: False
+Description: TypeDependencyNamespace.ChildClass does exist
+Result: False
+Description: TypeDependencyNamespace.OtherChildClass does exist
+Message: 
+"Types that depend on "TypeDependencyNamespace.BaseClass" should not exist" failed:
+	TypeDependencyNamespace.ChildClass does exist
+	TypeDependencyNamespace.OtherChildClass does exist
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAnyAttributesTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAnyAttributesTest.verified.txt
@@ -1,0 +1,262 @@
+﻿===== No violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any attribute with full name "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any attribute with full name matching "^.*\.UnusedAttribute$"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any attribute with full name "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any attribute with full name matching "^.*\.UnusedAttribute$"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any Attributes that are "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any attribute with full name "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have any attribute with full name "AttributeNamespace.Attribute1"
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any attribute with full name "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have any attribute with full name "AttributeNamespace.Attribute1"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any attribute with full name "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have any attribute with full name "AttributeNamespace.Attribute1"
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any attribute with full name "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have any attribute with full name "AttributeNamespace.Attribute1"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any Attributes that are "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have any Attributes that are "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+===== Non-existent attribute =====
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should not have any attribute with full name "NotTheNameOfAnyObject"
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should not have any attribute with full name "NotTheNameOfAnyObject"
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+===== Type outside of architecture =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should not have attribute "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+===== Empty arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should not have one of no attributes (always true)
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should not have one of no attributes (always true)
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should not have one of no attributes (always true)
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should not have any Attributes that have full name "NotTheNameOfAnyObject"
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that have full name "NotTheNameOfAnyObject" should not have one of no attributes (always true)
+Message: 
+All Evaluations passed
+
+Query: Types that have full name "NotTheNameOfAnyObject" should not have one of no attributes (always true)
+Message: 
+All Evaluations passed
+
+Query: Types that have full name "NotTheNameOfAnyObject" should not have one of no attributes (always true)
+Message: 
+All Evaluations passed
+
+Query: Types that have full name "NotTheNameOfAnyObject" should not have any Attributes that have full name "NotTheNameOfAnyObject"
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should not have any attribute with full name "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have any attribute with full name "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should not have any attribute with full name "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"" failed:
+	AttributeNamespace.ClassWithAttributes does have any attribute with full name "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"" failed:
+	AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"" failed:
+	AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"" failed:
+	AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"" failed:
+	AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should not have any Attributes that are "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" should not have any Attributes that are "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"" failed:
+	AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" or "AttributeNamespace.OtherClassWithoutAttributes" should not have attribute "AttributeNamespace.Attribute2"
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Result: True
+Description: AttributeNamespace.OtherClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" or "AttributeNamespace.OtherClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Result: False
+Description: AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithoutAttributes" or "AttributeNamespace.OtherClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAnyAttributesThatTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAnyAttributesThatTest.verified.txt
@@ -1,0 +1,19 @@
+﻿===== No violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attributes that are "AttributeNamespace.UnusedAttribute"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attributes that are "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should not have attributes that are "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAnyAttributesWithArgumentsTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAnyAttributesWithArgumentsTest.verified.txt
@@ -66,7 +66,7 @@ Message:
 
 
 
-===== Type without attrubites =====
+===== Type without attributes =====
 
 Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should not have any attributes with arguments "Argument"
 Result: True

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAnyAttributesWithArgumentsTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAnyAttributesWithArgumentsTest.verified.txt
@@ -1,0 +1,136 @@
+﻿===== No violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "AttributeNamespace.UnusedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "AttributeNamespace.UnusedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== No violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "UnusedValueArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "UnusedValueArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "AttributeNamespace.TypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "AttributeNamespace.TypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "AttributeNamespace.TypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "AttributeNamespace.TypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "0"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "0"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Type without attrubites =====
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should not have any attributes with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+===== Null argument =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments ""
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Empty arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have no or any attributes with arguments (impossible)
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "AttributeNamespace.UnusedTypeArgument" and "Argument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "AttributeNamespace.UnusedTypeArgument" and "Argument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "AttributeNamespace.UnusedTypeArgument" and "Argument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with arguments "AttributeNamespace.UnusedTypeArgument" and "Argument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have any attributes with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have any attributes with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have any attributes with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have any attributes with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with argument values "Argument" and "Argument" and "0" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedArgument" and "1" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "OtherArgument" and "2" and "OtherNamedArgument" and "3" and "ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAnyAttributesWithNamedArgumentsTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAnyAttributesWithNamedArgumentsTest.verified.txt
@@ -1,0 +1,144 @@
+﻿===== No violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "OtherNamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.OtherNamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== No violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "OtherNamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "OtherNamedParameter2=NamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter2=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter2=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Empty arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have no or any attributes with named arguments (impossible)
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have any attributes with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments does have attributes with named arguments "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter1=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]" and "NamedParameter2=NamedArgument" and "NamedParameter3=1" and "OtherNamedParameter1=OtherNamedArgument" and "OtherNamedParameter2=3" and "OtherNamedParameter3=ArchUnitNET.Domain.TypeInstance`1[ArchUnitNET.Domain.Class]"
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAttributeWithArgumentsTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAttributeWithArgumentsTest.verified.txt
@@ -1,0 +1,407 @@
+﻿===== No violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== No violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.OtherTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+===== Violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "0"" failed:
+	AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "0"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "0"" failed:
+	AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "0"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "0"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "0"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "0"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "0"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "0"
+
+
+
+===== Unused attribute =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.UnusedAttribute" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.UnusedAttribute" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Type outside of architecture =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "TypeDependencyNamespace.BaseClass" with arguments "1"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Null argument =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.UnusedAttribute" with arguments ""
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with arguments ""
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with arguments ""
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Empty arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1"
+
+
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"" failed:
+	AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"" failed:
+	AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "AttributeNamespace.TypeArgument" and "0"
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with arguments "Argument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with arguments "Argument"
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAttributeWithNamedArgumentsTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveAttributeWithNamedArgumentsTest.verified.txt
@@ -1,0 +1,387 @@
+﻿===== No violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== No violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "OtherNamedParameter1=OtherNamedArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Violations with type arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+===== Violations with value arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter2=NamedArgument"
+
+
+
+===== Unused attribute =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.UnusedAttribute" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithArguments passed
+Message: 
+All Evaluations passed
+
+===== Type outside of architecture =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should does have attribute "TypeDependencyNamespace.BaseClass" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+===== Empty arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1"
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1"
+
+
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter...
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter..." failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument" and "NamedParameter2=NamedArgument"
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Result: False
+Description: AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+Message: 
+"Types that are "AttributeNamespace.ClassWithArguments" or "AttributeNamespace.ClassWithAttributes" should does have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"" failed:
+	AttributeNamespace.ClassWithArguments not have attribute "AttributeNamespace.Attribute1" with named arguments "NamedParameter1=AttributeNamespace.NamedTypeArgument"
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveNameTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.NotHaveNameTest.verified.txt
@@ -1,0 +1,124 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have name "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have name matching "^.*\.Base.*$"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have full name "BaseClass"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have full name matching "^Base.*$"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have name containing "TypeDependencyNamespace"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have full name containing "NotTheNameOfAnyObject"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have name starting with "TypeDependencyNamespace"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have name ending with "Base"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have name "BaseClass"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have name BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not have name "BaseClass"" failed:
+	TypeDependencyNamespace.BaseClass does have name BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have name matching "^Base.*$"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have name BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not have name matching "^Base.*$"" failed:
+	TypeDependencyNamespace.BaseClass does have name BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have full name "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not have full name "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have full name matching "^.*\.Base.*$"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not have full name matching "^.*\.Base.*$"" failed:
+	TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have name containing "Base"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have name BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not have name containing "Base"" failed:
+	TypeDependencyNamespace.BaseClass does have name BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have full name containing "TypeDependencyNamespace"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not have full name containing "TypeDependencyNamespace"" failed:
+	TypeDependencyNamespace.BaseClass does have full name TypeDependencyNamespace.BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have name starting with "Base"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have name BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not have name starting with "Base"" failed:
+	TypeDependencyNamespace.BaseClass does have name BaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should not have name ending with "Class"
+Result: False
+Description: TypeDependencyNamespace.BaseClass does have name BaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.BaseClass" should not have name ending with "Class"" failed:
+	TypeDependencyNamespace.BaseClass does have name BaseClass
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyDependOnTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyDependOnTest.verified.txt
@@ -141,11 +141,14 @@ Message:
 
 ===== Type outside of architecture =====
 
-Query: Types that are "TypeDependencyNamespace.BaseClass" should only depend on "AttributeNamespace.ClassWithoutAttributes"
-Result: True
-Description: TypeDependencyNamespace.BaseClass passed
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "AttributeNamespace.ClassWithoutAttributes"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
-All Evaluations passed
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "AttributeNamespace.ClassWithoutAttributes"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
 
 ===== Empty arguments =====
 

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyDependOnTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyDependOnTest.verified.txt
@@ -1,0 +1,243 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should only depend on types with full name "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should only depend on types with full name matching "^.*\.BaseClass$"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should only depend on types with full name "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should only depend on types with full name matching "^.*\.BaseClass$"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should only depend on "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should only depend on "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should only depend on Classes that are "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should only depend on "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should only depend on "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that are "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that are "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+===== Non-existent type =====
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "NotTheNameOfAnyObject"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "NotTheNameOfAnyObject"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "NotTheNameOfAnyObject"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "NotTheNameOfAnyObject"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+
+
+
+===== Type outside of architecture =====
+
+Query: Types that are "TypeDependencyNamespace.BaseClass" should only depend on "AttributeNamespace.ClassWithoutAttributes"
+Result: True
+Description: TypeDependencyNamespace.BaseClass passed
+Message: 
+All Evaluations passed
+
+===== Empty arguments =====
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that have full name "NotTheNameOfAnyObject"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that have full name "NotTheNameOfAnyObject"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+
+===== Multiple arguments =====
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and System.Object
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and System.Object
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+
+
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that are "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that are "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyDependOnTypesThatTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyDependOnTypesThatTest.verified.txt
@@ -1,0 +1,19 @@
+﻿===== No violations =====
+
+Query: Types that are "TypeDependencyNamespace.ChildClass" should only depend on types that have full name "TypeDependencyNamespace.BaseClass"
+Result: True
+Description: TypeDependencyNamespace.ChildClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types that have full name "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Message: 
+"Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types that have full name "TypeDependencyNamespace.BaseClass"" failed:
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyHaveAttributesTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyHaveAttributesTest.verified.txt
@@ -1,0 +1,338 @@
+﻿===== No violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name matching "^.*\.Attribute1$"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name matching "^.*\.Attribute1$"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should does only have Attributes that are "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should does only have Attributes that are "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should does only have Attributes that are "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+===== Non-existent attribute =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name "NotTheNameOfAnyObject"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does not only have attributes with full name "NotTheNameOfAnyObject"
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name "NotTheNameOfAnyObject"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does not only have attributes with full name "NotTheNameOfAnyObject"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name "NotTheNameOfAnyObject"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does not only have attributes with full name "NotTheNameOfAnyObject"
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes with full name "NotTheNameOfAnyObject"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does not only have attributes with full name "NotTheNameOfAnyObject"
+
+
+
+===== Attribute outside of architecture =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "TypeDependencyNamespace.BaseClass"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes "TypeDependencyNamespace.BaseClass"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+===== Empty arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should have no attributes
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attributes
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should have no attributes" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attributes
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should have no attributes
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should have no attributes" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should have no attributes
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should have no attributes" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should does only have Attributes that have full name "NotTheNameOfAnyObject"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should does only have Attributes that have full name "NotTheNameOfAnyObject"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should have no attributes
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should have no attributes
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should have no attributes
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithoutAttributes" should does only have Attributes that have full name "NotTheNameOfAnyObject"
+Result: True
+Description: AttributeNamespace.ClassWithoutAttributes passed
+Message: 
+All Evaluations passed
+
+===== Multiple arguments =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should only have attributes with full name "AttributeNamespace.Attribute1" and "AttributeNamespace.Attribute2"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should only have attributes "AttributeNamespace.Attribute1" and "AttributeNamespace.Attribute2"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should only have attributes "AttributeNamespace.Attribute1" and "AttributeNamespace.Attribute2"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should only have attributes "AttributeNamespace.Attribute1" and "AttributeNamespace.Attribute2"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should only have attributes "AttributeNamespace.Attribute1" and "AttributeNamespace.Attribute2"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" should does only have Attributes that are "AttributeNamespace.Attribute1" or "AttributeNamespace.Attribute2"
+Result: True
+Description: AttributeNamespace.ClassWithAttributes passed
+Message: 
+All Evaluations passed
+
+===== Multiple inputs =====
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes with full name "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.OtherClassWithAttributes does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes with full name "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+	AttributeNamespace.OtherClassWithAttributes does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes with full name "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.OtherClassWithAttributes does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes with full name "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+	AttributeNamespace.OtherClassWithAttributes does not only have attributes with full name "AttributeNamespace.UnusedAttribute"
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Result: False
+Description: AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+	AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Result: False
+Description: AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+	AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Result: False
+Description: AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+	AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Result: False
+Description: AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should only have attributes "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+	AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+
+
+
+Query: Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should does only have Attributes that are "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Result: False
+Description: AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+Message: 
+"Types that are "AttributeNamespace.ClassWithAttributes" or "AttributeNamespace.OtherClassWithAttributes" should does only have Attributes that are "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+	AttributeNamespace.OtherClassWithAttributes does have attribute AttributeNamespace.Attribute1 and AttributeNamespace.Attribute2
+
+
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyHaveAttributesThatTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyHaveAttributesThatTest.verified.txt
@@ -1,0 +1,19 @@
+﻿===== No violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes that have full name "AttributeNamespace.Attribute1"
+Result: True
+Description: AttributeNamespace.ClassWithSingleAttribute passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+Query: Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes that have full name "AttributeNamespace.UnusedAttribute"
+Result: False
+Description: AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+Message: 
+"Types that are "AttributeNamespace.ClassWithSingleAttribute" should only have attributes that have full name "AttributeNamespace.UnusedAttribute"" failed:
+	AttributeNamespace.ClassWithSingleAttribute does have attribute AttributeNamespace.Attribute1
+
+
+

--- a/ArchUnitNETTests/Loader/ArchLoaderTests.cs
+++ b/ArchUnitNETTests/Loader/ArchLoaderTests.cs
@@ -67,7 +67,7 @@ namespace ArchUnitNETTests.Loader
                 .LoadAssembliesRecursively(new[] { typeof(BaseClass).Assembly }, filterFunc)
                 .Build();
 
-            Assert.Equal(1, architecture.Assemblies.Count());
+            Assert.Single(architecture.Assemblies);
         }
     }
 }

--- a/ArchUnitNETTests/StaticTestArchitectures.cs
+++ b/ArchUnitNETTests/StaticTestArchitectures.cs
@@ -25,6 +25,18 @@ namespace ArchUnitNETTests
             .LoadAssemblies(typeof(BaseClass).Assembly)
             .Build();
 
+        public static readonly Architecture AttributeArchitecture = new ArchLoader()
+            .LoadAssemblies(typeof(AttributeNamespace.ClassWithoutAttributes).Assembly)
+            .Build();
+
+        public static readonly Architecture DependencyArchitecture = new ArchLoader()
+            .LoadAssemblies(typeof(TypeDependencyNamespace.BaseClass).Assembly)
+            .Build();
+
+        public static readonly Architecture VisibilityArchitecture = new ArchLoader()
+            .LoadAssemblies(typeof(VisibilityNamespace.PublicClass).Assembly)
+            .Build();
+
         public static readonly Architecture ArchUnitNETTestAssemblyArchitecture = new ArchLoader()
             .LoadAssemblies(typeof(Class1).Assembly)
             .Build();

--- a/TestAssemblies/AttributeAssembly/AttributeAssembly.cs
+++ b/TestAssemblies/AttributeAssembly/AttributeAssembly.cs
@@ -1,0 +1,107 @@
+﻿namespace AttributeNamespace;
+
+public class TypeArgument { };
+
+public class OtherTypeArgument { };
+
+public class NamedTypeArgument { }
+
+public class OtherNamedTypeArgument { }
+
+public class UnusedTypeArgument { }
+
+[System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct)]
+public class Attribute1 : System.Attribute
+{
+    public Attribute1(string parameter1 = "", int parameter2 = -1, System.Type parameter3 = null)
+    { }
+
+    public System.Type NamedParameter1 { get; set; }
+
+    public string NamedParameter2 { get; set; }
+
+    public int NamedParameter3 { get; set; }
+}
+
+[System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct)]
+public class Attribute2 : System.Attribute
+{
+    public Attribute2(System.Type parameter1 = null, string parameter2 = "", int parameter3 = -1)
+    { }
+
+    public string OtherNamedParameter1 { get; set; }
+
+    public int OtherNamedParameter2 { get; set; }
+
+    public System.Type OtherNamedParameter3 { get; set; }
+}
+
+[System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct)]
+public class UnusedAttribute : System.Attribute
+{
+    public UnusedAttribute(
+        int unusedParameter1 = -1,
+        System.Type unusedParameter2 = null,
+        string unusedParameter3 = ""
+    ) { }
+
+    public int UnusedNamedParameter1 { get; set; }
+
+    public System.Type UnusedNamedParameter2 { get; set; }
+
+    public string UnusedNamedParameter3 { get; set; }
+}
+
+public class ClassWithoutAttributes { }
+
+public class OtherClassWithoutAttributes { }
+
+[Attribute1]
+public class ClassWithSingleAttribute { }
+
+[Attribute1]
+public class OtherClassWithSingleAttribute { }
+
+[Attribute1]
+[Attribute2]
+public class ClassWithAttributes { }
+
+[Attribute1]
+[Attribute2]
+public class OtherClassWithAttributes { }
+
+[Attribute1(
+    "Argument",
+    0,
+    typeof(TypeArgument),
+    NamedParameter1 = typeof(NamedTypeArgument),
+    NamedParameter2 = "NamedArgument",
+    NamedParameter3 = 1
+)]
+[Attribute2(
+    typeof(OtherTypeArgument),
+    "OtherArgument",
+    2,
+    OtherNamedParameter1 = "OtherNamedArgument",
+    OtherNamedParameter2 = 3,
+    OtherNamedParameter3 = typeof(OtherNamedTypeArgument)
+)]
+public class ClassWithArguments { }
+
+[Attribute1(
+    "Argument",
+    0,
+    typeof(TypeArgument),
+    NamedParameter1 = typeof(NamedTypeArgument),
+    NamedParameter2 = "NamedArgument",
+    NamedParameter3 = 1
+)]
+[Attribute2(
+    typeof(OtherTypeArgument),
+    "OtherArgument",
+    2,
+    OtherNamedParameter1 = "OtherNamedArgument",
+    OtherNamedParameter2 = 3,
+    OtherNamedParameter3 = typeof(OtherNamedTypeArgument)
+)]
+public class OtherClassWithArguments { }

--- a/TestAssemblies/AttributeAssembly/AttributeAssembly.csproj
+++ b/TestAssemblies/AttributeAssembly/AttributeAssembly.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssemblies/DependencyAssembly/DependencyAssembly.csproj
+++ b/TestAssemblies/DependencyAssembly/DependencyAssembly.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssemblies/DependencyAssembly/MethodDependency.cs
+++ b/TestAssemblies/DependencyAssembly/MethodDependency.cs
@@ -1,0 +1,26 @@
+namespace MethodDependencyNamespace;
+
+public class MethodDependencyClass
+{
+    public void MethodWithSingleDependency()
+    {
+        CalledMethod();
+    }
+
+    public void CalledMethod() { }
+
+    public void MethodWithMultipleDependencies()
+    {
+        CalledMethod1();
+        CalledMethod2();
+        CalledMethod3();
+    }
+
+    public void CalledMethod1() { }
+
+    public void CalledMethod2() { }
+
+    public void CalledMethod3() { }
+
+    public void MethodWithoutDependencies() { }
+}

--- a/TestAssemblies/DependencyAssembly/TypeDependency.cs
+++ b/TestAssemblies/DependencyAssembly/TypeDependency.cs
@@ -1,0 +1,45 @@
+﻿namespace TypeDependencyNamespace;
+
+public abstract class BaseClass { }
+
+public class ChildClass : BaseClass { }
+
+public class OtherChildClass : BaseClass { }
+
+public abstract class BaseClassWithMember
+{
+    public string BaseClassMember { get; set; }
+}
+
+public class ChildClassWithMember : BaseClassWithMember
+{
+    public string ChildClassMember { get; set; }
+}
+
+public class OtherChildClassWithMember : BaseClassWithMember
+{
+    public string OtherChildClassMember { get; set; }
+}
+
+public abstract class BaseClassWithMultipleDependencies { }
+
+public class ChildClass1 : BaseClassWithMultipleDependencies { }
+
+public class ChildClass2 : BaseClassWithMultipleDependencies { }
+
+public class OtherBaseClass { }
+
+public class ClassWithMultipleDependencies
+{
+    public BaseClassWithMember _baseClass;
+    public OtherBaseClass _otherBaseClass;
+}
+
+public abstract class GenericBaseClass<TSelf>
+    where TSelf : class { }
+
+public class ChildClassOfGeneric : GenericBaseClass<ChildClassOfGeneric> { }
+
+public class ClassWithoutDependencies { }
+
+public class OtherClassWithoutDependencies { }

--- a/TestAssemblies/VisibilityAssembly/VisibilityAssembly.csproj
+++ b/TestAssemblies/VisibilityAssembly/VisibilityAssembly.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssemblies/VisibilityAssembly/VisibilityClasses.cs
+++ b/TestAssemblies/VisibilityAssembly/VisibilityClasses.cs
@@ -1,0 +1,36 @@
+﻿namespace VisibilityNamespace;
+
+public class PublicClass { }
+
+public class OtherPublicClass { }
+
+internal class InternalClass { }
+
+internal class OtherInternalClass { }
+
+public class OuterClass
+{
+    public class PublicInnerClass { }
+
+    public class OtherPublicInnerClass { }
+
+    internal class InternalInnerClass { }
+
+    internal class OtherInternalInnerClass { }
+
+    protected internal class ProtectedInternalInnerClass { }
+
+    protected internal class OtherProtectedInternalInnerClass { }
+
+    protected class ProtectedInnerClass { }
+
+    protected class OtherProtectedInnerClass { }
+
+    private protected class PrivateProtectedInnerClass { }
+
+    private protected class OtherPrivateProtectedInnerClass { }
+
+    private class PrivateInnerClass { }
+
+    private class OtherPrivateInnerClass { }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,11 @@
   "packageRules": [
     {
       "matchManagers": ["nuget"],
+      "matchFileNames": [
+        "ArchUnitNET.MSTestV2/ArchUnitNET.MSTestV2.csproj",
+        "ArchUnitNET.NUnit/ArchUnitNET.NUnit.csproj",
+        "ArchUnitNET.XUnit/ArchUnitNET.XUnit.csproj"
+      ],
       "matchPackagePrefixes": ["xunit", "nunit", "NUnit", "MSTest"],
       "matchPackageNames": ["Microsoft.NET.Test.Sdk", "JetBrains.Annotations"],
       "enabled": false


### PR DESCRIPTION
With this PR we add new test cases for methods defined in `ArchUnitNET/Fluent/Syntax/Elements/ObjectsShould.cs` and `ArchUnitNET/Fluent/Syntax/Elements/ObjectConditionsDefinition.cs` that achieves the following:
- We achieve full line coverage and nearly full branch coverage by testing a larger subset of the interface and more combinations of arguments
- We allow for the detection of regressions in the error messages by adding snapshot tests
- The new tests have an improved execution time compared to the older tests, because we do not use the whole `ArchUnitNETTests` assembly as the architecture for our tests. Instead, we add separate assemblies that contain a small number of types. This reduces the number of hits per line from hundreds or thousands to usually less than ten.

The new tests will replace tests in `ArchUnitNETTests/Fluent/Syntax/Elements/ObjectSyntaxElementsTests.cs`, but to remove these tests without reducing the code coverage, additional tests for `ArchUnitNET/Fluent/Syntax/Elements/ObjectPredicatesDefinition.cs` will be needed.

Relates to #229, providing a way to check for changes to the error messages in pull requests