### PR TITLE
Loader: Match Types By Assembly Qualified Name

### DIFF
--- a/ArchUnit.sln
+++ b/ArchUnit.sln
@@ -28,6 +28,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeAssembly", "TestAs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisibilityAssembly", "TestAssemblies\VisibilityAssembly\VisibilityAssembly.csproj", "{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoaderTestAssembly", "TestAssemblies\LoaderTestAssembly\LoaderTestAssembly.csproj", "{0243F2D4-AC89-4561-A936-D647B6BB821F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtherLoaderTestAssembly", "TestAssemblies\OtherLoaderTestAssembly\OtherLoaderTestAssembly.csproj", "{5A24529B-1794-4080-ADCC-77440BA0A0B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +86,14 @@ Global
 		{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0243F2D4-AC89-4561-A936-D647B6BB821F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0243F2D4-AC89-4561-A936-D647B6BB821F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0243F2D4-AC89-4561-A936-D647B6BB821F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0243F2D4-AC89-4561-A936-D647B6BB821F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A24529B-1794-4080-ADCC-77440BA0A0B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A24529B-1794-4080-ADCC-77440BA0A0B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A24529B-1794-4080-ADCC-77440BA0A0B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A24529B-1794-4080-ADCC-77440BA0A0B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,5 +102,7 @@ Global
 		{10A70A38-A18D-4FA8-AF25-2B25B3D60BE6} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 		{FB457140-47B4-4B20-8505-BA9BFC73C705} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 		{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
+		{0243F2D4-AC89-4561-A936-D647B6BB821F} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
+		{5A24529B-1794-4080-ADCC-77440BA0A0B3} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 	EndGlobalSection
 EndGlobal

--- a/ArchUnitNET/Loader/ArchBuilder.cs
+++ b/ArchUnitNET/Loader/ArchBuilder.cs
@@ -111,10 +111,17 @@ namespace ArchUnitNET.Loader
                 .ForEach(typeDefinition =>
                 {
                     var type = _typeFactory.GetOrCreateTypeFromTypeReference(typeDefinition);
-                    if (!_architectureTypes.ContainsKey(type.FullName) && !type.IsCompilerGenerated)
+                    var assemblyQualifiedName = System.Reflection.Assembly.CreateQualifiedName(
+                        module.Assembly.Name.Name,
+                        typeDefinition.FullName
+                    );
+                    if (
+                        !_architectureTypes.ContainsKey(assemblyQualifiedName)
+                        && !type.IsCompilerGenerated
+                    )
                     {
                         currentTypes.Add(type);
-                        _architectureTypes.Add(type.FullName, type);
+                        _architectureTypes.Add(assemblyQualifiedName, type);
                     }
                 });
 

--- a/ArchUnitNET/Loader/TypeFactory.cs
+++ b/ArchUnitNET/Loader/TypeFactory.cs
@@ -4,10 +4,8 @@
 //
 // 	SPDX-License-Identifier: Apache-2.0
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using ArchUnitNET.Domain;
 using ArchUnitNET.Loader.LoadTasks;

--- a/ArchUnitNET/Loader/TypeRegistry.cs
+++ b/ArchUnitNET/Loader/TypeRegistry.cs
@@ -23,8 +23,12 @@ namespace ArchUnitNET.Loader
             [NotNull] Func<string, ITypeInstance<IType>> createFunc
         )
         {
+            var assemblyQualifiedName = System.Reflection.Assembly.CreateQualifiedName(
+                typeReference.Module.Assembly.FullName,
+                typeReference.BuildFullName()
+            );
             return RegistryUtils.GetFromDictOrCreateAndAdd(
-                typeReference.BuildFullName(),
+                assemblyQualifiedName,
                 _allTypes,
                 createFunc
             );

--- a/ArchUnitNETTests/ArchUnitNETTests.csproj
+++ b/ArchUnitNETTests/ArchUnitNETTests.csproj
@@ -12,6 +12,9 @@
     <ProjectReference Include="..\TestAssembly\TestAssembly.csproj" />
     <ProjectReference Include="..\TestAssemblies\AttributeAssembly\AttributeAssembly.csproj" />
     <ProjectReference Include="..\TestAssemblies\DependencyAssembly\DependencyAssembly.csproj" />
+    <ProjectReference Include="..\TestAssemblies\LoaderTestAssembly\LoaderTestAssembly.csproj" />
+    <ProjectReference
+      Include="..\TestAssemblies\OtherLoaderTestAssembly\OtherLoaderTestAssembly.csproj" />
     <ProjectReference Include="..\TestAssemblies\VisibilityAssembly\VisibilityAssembly.csproj" />
   </ItemGroup>
 

--- a/ArchUnitNETTests/Loader/ArchLoaderTests.cs
+++ b/ArchUnitNETTests/Loader/ArchLoaderTests.cs
@@ -26,6 +26,19 @@ namespace ArchUnitNETTests.Loader
         }
 
         [Fact]
+        public void SameFullNameInMultipleAssemblies()
+        {
+            var types = LoaderTestArchitecture.Types.Where(type =>
+                type.Namespace.FullName == "DuplicateClassAcrossAssemblies"
+            );
+            Assert.Equal(2, types.Count());
+            Assert.Single(types.Where(type => type.Assembly.Name.StartsWith("LoaderTestAssembly")));
+            Assert.Single(
+                types.Where(type => type.Assembly.Name.StartsWith("OtherLoaderTestAssembly"))
+            );
+        }
+
+        [Fact]
         public void LoadAssembliesIncludingRecursiveDependencies()
         {
             var archUnitNetTestArchitectureWithRecursiveDependencies = new ArchLoader()

--- a/ArchUnitNETTests/StaticTestArchitectures.cs
+++ b/ArchUnitNETTests/StaticTestArchitectures.cs
@@ -33,6 +33,13 @@ namespace ArchUnitNETTests
             .LoadAssemblies(typeof(TypeDependencyNamespace.BaseClass).Assembly)
             .Build();
 
+        public static readonly Architecture LoaderTestArchitecture = new ArchLoader()
+            .LoadAssemblies(
+                typeof(LoaderTestAssembly.LoaderTestAssembly).Assembly,
+                typeof(OtherLoaderTestAssembly.OtherLoaderTestAssembly).Assembly
+            )
+            .Build();
+
         public static readonly Architecture VisibilityArchitecture = new ArchLoader()
             .LoadAssemblies(typeof(VisibilityNamespace.PublicClass).Assembly)
             .Build();

--- a/TestAssemblies/LoaderTestAssembly/DuplicateClassAcrossAssemblies.cs
+++ b/TestAssemblies/LoaderTestAssembly/DuplicateClassAcrossAssemblies.cs
@@ -1,0 +1,3 @@
+﻿namespace DuplicateClassAcrossAssemblies;
+
+internal class DuplicateClass { }

--- a/TestAssemblies/LoaderTestAssembly/LoaderTestAssembly.cs
+++ b/TestAssemblies/LoaderTestAssembly/LoaderTestAssembly.cs
@@ -1,0 +1,3 @@
+namespace LoaderTestAssembly;
+
+public class LoaderTestAssembly { }

--- a/TestAssemblies/LoaderTestAssembly/LoaderTestAssembly.csproj
+++ b/TestAssemblies/LoaderTestAssembly/LoaderTestAssembly.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssemblies/OtherLoaderTestAssembly/DuplicateClassAcrossAssemblies.cs
+++ b/TestAssemblies/OtherLoaderTestAssembly/DuplicateClassAcrossAssemblies.cs
@@ -1,0 +1,3 @@
+﻿namespace DuplicateClassAcrossAssemblies;
+
+internal class DuplicateClass { }

--- a/TestAssemblies/OtherLoaderTestAssembly/OtherLoaderTestAssembly.cs
+++ b/TestAssemblies/OtherLoaderTestAssembly/OtherLoaderTestAssembly.cs
@@ -1,0 +1,3 @@
+namespace OtherLoaderTestAssembly;
+
+public class OtherLoaderTestAssembly { }

--- a/TestAssemblies/OtherLoaderTestAssembly/OtherLoaderTestAssembly.csproj
+++ b/TestAssemblies/OtherLoaderTestAssembly/OtherLoaderTestAssembly.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #292, adding the ability to `ArchBuilder` and `TypeRegistry` to differentiate between types with the same full name but from different assemblies.