### PR TITLE
Completely Filter Compiler Attributes from Architecture

### DIFF
--- a/ArchUnitNET/Loader/LoadTasks/AddAttributesAndAttributeDependencies.cs
+++ b/ArchUnitNET/Loader/LoadTasks/AddAttributesAndAttributeDependencies.cs
@@ -175,9 +175,16 @@ namespace ArchUnitNET.Loader.LoadTasks
             IEnumerable<CustomAttribute> customAttributes
         )
         {
-            return customAttributes.Select(attr =>
-                attr.CreateAttributeFromCustomAttribute(_typeFactory)
-            );
+            return customAttributes
+                .Where(customAttribute =>
+                    customAttribute.AttributeType.FullName
+                        != "Microsoft.CodeAnalysis.EmbeddedAttribute"
+                    && customAttribute.AttributeType.FullName
+                        != "System.Runtime.CompilerServices.NullableAttribute"
+                    && customAttribute.AttributeType.FullName
+                        != "System.Runtime.CompilerServices.NullableContextAttribute"
+                )
+                .Select(attr => attr.CreateAttributeFromCustomAttribute(_typeFactory));
         }
 
         [NotNull]

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.DependOnAnyTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.DependOnAnyTest.verified.txt
@@ -76,46 +76,46 @@ Message:
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any Classes that are "TypeDependencyNamespace.ClassWithoutDependencies"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any Classes that are "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
@@ -143,10 +143,10 @@ Message:
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "AttributeNamespace.ClassWithoutAttributes"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "AttributeNamespace.ClassWithoutAttributes"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
@@ -163,28 +163,28 @@ Message:
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on one of no types (impossible)
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on one of no types (impossible)" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on one of no types (impossible)
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on one of no types (impossible)" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any Classes that have full name "NotTheNameOfAnyObject"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on any Classes that have full name "NotTheNameOfAnyObject"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
@@ -201,37 +201,37 @@ Message:
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that have full name "TypeDependencyNamespace.ClassWithMultipleDependencies" should depend on "TypeDependencyNamespace.ClassWithoutDependencies" or "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyDependOnTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyDependOnTest.verified.txt
@@ -58,64 +58,64 @@ All Evaluations passed
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that are "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that are "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
@@ -123,19 +123,19 @@ Message:
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "NotTheNameOfAnyObject"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "NotTheNameOfAnyObject"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "NotTheNameOfAnyObject"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "NotTheNameOfAnyObject"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
 
 
 
@@ -143,10 +143,10 @@ Message:
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "AttributeNamespace.ClassWithoutAttributes"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "AttributeNamespace.ClassWithoutAttributes"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
@@ -154,37 +154,37 @@ Message:
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass and System.Object
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should have no dependencies" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that have full name "NotTheNameOfAnyObject"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that have full name "NotTheNameOfAnyObject"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 
@@ -192,55 +192,55 @@ Message:
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and System.Object
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and System.Object
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types with full name "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and System.Object
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and System.Object
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember
 
 
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that are "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on Classes that are "TypeDependencyNamespace.BaseClass" or "TypeDependencyNamespace.OtherBaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember
 
 
 

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyDependOnTypesThatTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/ObjectsShouldTests.OnlyDependOnTypesThatTest.verified.txt
@@ -10,10 +10,10 @@ All Evaluations passed
 
 Query: Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types that have full name "TypeDependencyNamespace.BaseClass"
 Result: False
-Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+Description: TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 Message: 
 "Types that are "TypeDependencyNamespace.ClassWithMultipleDependencies" should only depend on types that have full name "TypeDependencyNamespace.BaseClass"" failed:
-	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and System.Runtime.CompilerServices.NullableContextAttribute and System.Runtime.CompilerServices.NullableAttribute and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
+	TypeDependencyNamespace.ClassWithMultipleDependencies does depend on System.Object and TypeDependencyNamespace.BaseClassWithMember and TypeDependencyNamespace.OtherBaseClass
 
 
 


### PR DESCRIPTION
Relates to #229. Compiler Attributes are currently filtered in the [`ArchBuilder`]( https://github.com/TNG/ArchUnitNET/blob/1bfa1e624924a8a76ffceaf17576c3cbd0c2a1c7/ArchUnitNET/Loader/ArchBuilder.cs#L82) but are still introduced to the architecture through the `AddAttributesAndAttributeDependencies` load task.

With this patch, the attributes `Microsoft.CodeAnalysis.EmbeddedAttribute`, `System.Runtime.CompilerServices.NullableAttribute` and `System.Runtime.CompilerServices.NullableContextAttribute` will also be filtered in that load task.