### PR TITLE
Correctly Resolve Assemblies for Types

### DIFF
--- a/ArchUnitNET/Domain/FunctionPointer.cs
+++ b/ArchUnitNET/Domain/FunctionPointer.cs
@@ -1,0 +1,93 @@
+// Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using ArchUnitNET.Domain.Dependencies;
+
+namespace ArchUnitNET.Domain
+{
+    public class FunctionPointer : IType
+    {
+        private readonly IType _type;
+
+        public FunctionPointer(
+            IType type,
+            ITypeInstance<IType> returnTypeInstance,
+            List<ITypeInstance<IType>> parameterTypeInstances
+        )
+        {
+            _type = type;
+            ReturnTypeInstance = returnTypeInstance;
+            ParameterTypeInstances = parameterTypeInstances;
+        }
+
+        public Namespace Namespace => _type.Namespace;
+        public Assembly Assembly => _type.Assembly;
+        public MemberList Members => _type.Members;
+        public IEnumerable<IType> ImplementedInterfaces => _type.ImplementedInterfaces;
+        public bool IsNested => _type.IsNested;
+        public bool IsStub => _type.IsStub;
+        public bool IsGenericParameter => _type.IsGenericParameter;
+        public string Name => _type.Name;
+        public string FullName => _type.FullName;
+        public Visibility Visibility => _type.Visibility;
+        public bool IsGeneric => _type.IsGeneric;
+        public List<GenericParameter> GenericParameters => _type.GenericParameters;
+        public bool IsCompilerGenerated => _type.IsCompilerGenerated;
+        public List<ITypeDependency> Dependencies => _type.Dependencies;
+        public List<ITypeDependency> BackwardsDependencies => _type.BackwardsDependencies;
+        public IEnumerable<Attribute> Attributes => _type.Attributes;
+        public List<AttributeInstance> AttributeInstances => _type.AttributeInstances;
+        public ITypeInstance<IType> ReturnTypeInstance { get; }
+        public List<ITypeInstance<IType>> ParameterTypeInstances { get; }
+
+        public bool Equals(FunctionPointer other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+            return Equals(_type, other._type)
+                && Equals(ReturnTypeInstance, other.ReturnTypeInstance)
+                && ParameterTypeInstances.SequenceEqual(other.ParameterTypeInstances);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            return obj.GetType() == GetType() && Equals((FunctionPointer)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = _type.GetHashCode();
+                hashCode =
+                    (hashCode * 397)
+                    ^ (ReturnTypeInstance != null ? ReturnTypeInstance.GetHashCode() : 0);
+                hashCode = ParameterTypeInstances.Aggregate(
+                    hashCode,
+                    (current, typeInstance) =>
+                        (current * 397) ^ (typeInstance != null ? typeInstance.GetHashCode() : 0)
+                );
+                return hashCode;
+            }
+        }
+    }
+}

--- a/ArchUnitNET/Loader/ArchLoaderException.cs
+++ b/ArchUnitNET/Loader/ArchLoaderException.cs
@@ -1,0 +1,17 @@
+// Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+//
+// 	SPDX-License-Identifier: Apache-2.0
+
+namespace ArchUnitNET.Loader
+{
+    public class ArchLoaderException : System.Exception
+    {
+        public ArchLoaderException(string message)
+            : base(message) { }
+
+        public ArchLoaderException(string message, System.Exception innerException)
+            : base(message, innerException) { }
+    }
+}

--- a/ArchUnitNET/Loader/TypeFactory.cs
+++ b/ArchUnitNET/Loader/TypeFactory.cs
@@ -4,6 +4,7 @@
 //
 // 	SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -199,14 +200,36 @@ namespace ArchUnitNET.Loader
                 }
             }
 
+            if (
+                typeReference.IsByReference
+                || typeReference.IsPointer
+                || typeReference.IsPinned
+                || typeReference.IsRequiredModifier
+            )
+            {
+                return CreateTypeFromTypeReference(typeReference.GetElementType(), isStub);
+            }
+
+            if (typeReference is FunctionPointerType functionPointerType)
+            {
+                return GetOrCreateTypeInstance(functionPointerType);
+            }
+
             TypeDefinition typeDefinition;
             try
             {
                 typeDefinition = typeReference.Resolve();
             }
-            catch (AssemblyResolutionException)
+            catch (AssemblyResolutionException e)
             {
-                typeDefinition = null;
+                throw new ArchLoaderException(
+                    $"Could not resolve type {typeReference.FullName}",
+                    e
+                );
+            }
+            if (typeDefinition == null)
+            {
+                throw new ArchLoaderException($"Could not resolve type {typeReference.FullName}");
             }
 
             var typeName = typeReference.BuildFullName();
@@ -230,26 +253,6 @@ namespace ArchUnitNET.Loader
             bool isCompilerGenerated,
                 isNested,
                 isGeneric;
-
-            if (typeDefinition == null)
-            {
-                isCompilerGenerated = typeReference.IsCompilerGenerated();
-                isNested = typeReference.IsNested;
-                isGeneric = typeReference.HasGenericParameters;
-                type = new Type(
-                    typeName,
-                    typeReference.Name,
-                    currentAssembly,
-                    currentNamespace,
-                    NotAccessible,
-                    isNested,
-                    isGeneric,
-                    true,
-                    isCompilerGenerated
-                );
-
-                return new TypeInstance<IType>(type);
-            }
 
             const string fixedElementField = "FixedElementField";
 
@@ -371,6 +374,35 @@ namespace ArchUnitNET.Loader
             }
 
             return createdTypeInstance;
+        }
+
+        [NotNull]
+        private ITypeInstance<FunctionPointer> GetOrCreateTypeInstance(
+            FunctionPointerType functionPointerType
+        )
+        {
+            var type = new Type(
+                functionPointerType.FullName,
+                functionPointerType.Name,
+                null,
+                null,
+                Public,
+                false,
+                false,
+                false,
+                false
+            );
+            var returnTypeInstance = GetOrCreateStubTypeInstanceFromTypeReference(
+                functionPointerType.ReturnType
+            );
+            var parameterTypeInstances = functionPointerType
+                .Parameters.Select(parameter =>
+                    GetOrCreateStubTypeInstanceFromTypeReference(parameter.ParameterType)
+                )
+                .ToList();
+            return new TypeInstance<FunctionPointer>(
+                new FunctionPointer(type, returnTypeInstance, parameterTypeInstances)
+            );
         }
 
         [NotNull]

--- a/ArchUnitNET/Loader/TypeFactory.cs
+++ b/ArchUnitNET/Loader/TypeFactory.cs
@@ -232,8 +232,8 @@ namespace ArchUnitNET.Loader
                 throw new ArchLoaderException($"Could not resolve type {typeReference.FullName}");
             }
 
-            var typeName = typeReference.BuildFullName();
-            var declaringTypeReference = typeReference;
+            var typeName = typeDefinition.BuildFullName();
+            var declaringTypeReference = typeDefinition;
             while (declaringTypeReference.IsNested)
             {
                 declaringTypeReference = declaringTypeReference.DeclaringType;
@@ -243,8 +243,8 @@ namespace ArchUnitNET.Loader
                 declaringTypeReference.Namespace
             );
             var currentAssembly = _assemblyRegistry.GetOrCreateAssembly(
-                typeReference.Module.Assembly.Name.FullName,
-                typeReference.Module.Assembly.FullName,
+                typeDefinition.Module.Assembly.Name.FullName,
+                typeDefinition.Module.Assembly.FullName,
                 true,
                 null
             );
@@ -315,7 +315,7 @@ namespace ArchUnitNET.Loader
             isGeneric = typeDefinition.HasGenericParameters;
             type = new Type(
                 typeName,
-                typeReference.Name,
+                typeDefinition.Name,
                 currentAssembly,
                 currentNamespace,
                 visibility,

--- a/ArchUnitNETTests/Domain/Dependencies/Members/MethodCallDependencyTests.cs
+++ b/ArchUnitNETTests/Domain/Dependencies/Members/MethodCallDependencyTests.cs
@@ -64,7 +64,7 @@ namespace ArchUnitNETTests.Domain.Dependencies.Members
             Assert.Contains(expectedDependency, originMember.GetMethodCallDependencies());
         }
 
-        [Theory]
+        [SkipInReleaseBuildTheory]
         [ClassData(typeof(MethodDependencyTestBuild.MethodCallDependencyInAsyncMethodTestData))]
         public void MethodCallDependenciesAreFoundInAsyncMethod(
             IMember originMember,

--- a/ArchUnitNETTests/Loader/ArchLoaderTests.cs
+++ b/ArchUnitNETTests/Loader/ArchLoaderTests.cs
@@ -6,8 +6,10 @@
 
 using System.Linq;
 using ArchUnitNET.Loader;
+using ArchUnitNET.xUnit;
 using ArchUnitNETTests.Domain.Dependencies.Members;
 using Xunit;
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
 using static ArchUnitNETTests.StaticTestArchitectures;
 
 namespace ArchUnitNETTests.Loader
@@ -81,6 +83,20 @@ namespace ArchUnitNETTests.Loader
                 .Build();
 
             Assert.Single(architecture.Assemblies);
+        }
+
+        [Fact]
+        public void TypesAreAssignedToCorrectAssemblies()
+        {
+            // https://github.com/TNG/ArchUnitNET/issues/302
+            var architecture = FullArchUnitNETArchitecture;
+            Types()
+                .That()
+                .ResideInAssembly(architecture.GetType().Assembly)
+                .Should()
+                .NotDependOnAnyTypesThat()
+                .ResideInAssembly(GetType().Assembly)
+                .Check(architecture);
         }
     }
 }

--- a/ArchUnitNETTests/Loader/TypeTests.cs
+++ b/ArchUnitNETTests/Loader/TypeTests.cs
@@ -4,6 +4,7 @@
 //
 // 	SPDX-License-Identifier: Apache-2.0
 
+using System.Linq;
 using ArchUnitNET.Domain;
 using ArchUnitNET.Domain.Dependencies;
 using ArchUnitNET.Domain.Extensions;
@@ -121,6 +122,17 @@ namespace ArchUnitNETTests.Loader
         public void NotAssignableToNull()
         {
             Assert.False(_type.IsAssignableTo(null));
+        }
+
+        [Fact]
+        public void TypesAreNotLoadedFromMultipleAssemblies()
+        {
+            var booleanType = _architecture
+                .Types.Concat(_architecture.ReferencedTypes)
+                .Where(type => type.FullName == "System.Boolean")
+                .ToList();
+            Assert.Single(booleanType);
+            Assert.False(booleanType.First().Assembly.Name.StartsWith("ArchUnitNET"));
         }
     }
 

--- a/ArchUnitNETTests/SkipInReleaseBuild.cs
+++ b/ArchUnitNETTests/SkipInReleaseBuild.cs
@@ -18,4 +18,14 @@ namespace ArchUnitNETTests
 #endif
         }
     }
+
+    public sealed class SkipInReleaseBuildTheory : TheoryAttribute
+    {
+        public SkipInReleaseBuildTheory()
+        {
+#if !DEBUG
+            Skip = "This test only works in debug build";
+#endif
+        }
+    }
 }


### PR DESCRIPTION
Currently, it can happen that types are either located in the wrong assembly or in multiple assemblies. With this patch, `TypeReference` instances are always resolved to `TypeDefinition` instances, if possible. While the `TypeReference` may reference the Assembly of tho caller, the `TypeDefinition` always correctly references the assembly of the callee.