### PR TITLE
Resolve Security Vulnerability Warnings

### DIFF
--- a/ArchUnitNET.NUnitTests/ArchUnitNET.NUnitTests.csproj
+++ b/ArchUnitNET.NUnitTests/ArchUnitNET.NUnitTests.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ArchUnitNET.xUnit/ArchUnitNET.xUnit.csproj
+++ b/ArchUnitNET.xUnit/ArchUnitNET.xUnit.csproj
@@ -25,6 +25,8 @@
 
     <ItemGroup>
         <PackageReference Include="xunit.assert" Version="2.4.1"/>
+        <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
`System.Net.Http` 4.3.0 and `System.Text.RegularExpressions` 4.3.0 have know security vulnerabilities. We update `NUnit3TestAdapter` in `ArchUnitNET.NUnitTests.csproj` and pin `System.Net.Http` and `System.Text.RegularExpressions` to fixed versions in `ArchUnitNET.xUnit.csproj` to resolve these warnings.