### PR TITLE
fix: dont throw exception if a type can not be resolved

### DIFF
--- a/ArchUnit.sln
+++ b/ArchUnit.sln
@@ -32,6 +32,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoaderTestAssembly", "TestA
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtherLoaderTestAssembly", "TestAssemblies\OtherLoaderTestAssembly\OtherLoaderTestAssembly.csproj", "{5A24529B-1794-4080-ADCC-77440BA0A0B3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FilteredDirectoryLoaderTestAssembly", "TestAssemblies\FilteredDirectoryLoaderTestAssembly\FilteredDirectoryLoaderTestAssembly.csproj", "{E6CB8C69-25F5-4C94-8EA3-D56E444EB46B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,10 @@ Global
 		{5A24529B-1794-4080-ADCC-77440BA0A0B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A24529B-1794-4080-ADCC-77440BA0A0B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A24529B-1794-4080-ADCC-77440BA0A0B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6CB8C69-25F5-4C94-8EA3-D56E444EB46B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6CB8C69-25F5-4C94-8EA3-D56E444EB46B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6CB8C69-25F5-4C94-8EA3-D56E444EB46B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6CB8C69-25F5-4C94-8EA3-D56E444EB46B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -104,5 +110,6 @@ Global
 		{FBCD91F2-4DB9-44AC-8214-6F2FFF9178D5} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 		{0243F2D4-AC89-4561-A936-D647B6BB821F} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 		{5A24529B-1794-4080-ADCC-77440BA0A0B3} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
+		{E6CB8C69-25F5-4C94-8EA3-D56E444EB46B} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 	EndGlobalSection
 EndGlobal

--- a/ArchUnitNET/Domain/UnavailableType.cs
+++ b/ArchUnitNET/Domain/UnavailableType.cs
@@ -1,0 +1,75 @@
+// Copyright 2019 Florian Gather <florian.gather@tngtech.com>
+// 	Copyright 2019 Fritz Brandhuber <fritz.brandhuber@tngtech.com>
+// 	Copyright 2020 Pavel Fischer <rubbiroid@gmail.com>
+//
+// 	SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using ArchUnitNET.Domain.Dependencies;
+
+namespace ArchUnitNET.Domain
+{
+    public class UnavailableType : IType
+    {
+        public UnavailableType(IType type)
+        {
+            Type = type;
+        }
+
+        private IType Type { get; }
+        public string Name => Type.Name;
+        public string FullName => Type.FullName;
+
+        public Visibility Visibility => Type.Visibility;
+        public bool IsNested => Type.IsNested;
+        public bool IsGeneric => Type.IsGeneric;
+        public bool IsGenericParameter => Type.IsGenericParameter;
+        public bool IsStub => true;
+        public bool IsCompilerGenerated => Type.IsCompilerGenerated;
+
+        public Namespace Namespace => Type.Namespace;
+        public Assembly Assembly => Type.Assembly;
+
+        public IEnumerable<Attribute> Attributes =>
+            AttributeInstances.Select(instance => instance.Type);
+        public List<AttributeInstance> AttributeInstances => Type.AttributeInstances;
+
+        public List<ITypeDependency> Dependencies => Type.Dependencies;
+        public List<ITypeDependency> BackwardsDependencies => Type.BackwardsDependencies;
+        public IEnumerable<IType> ImplementedInterfaces => Type.ImplementedInterfaces;
+
+        public MemberList Members => Type.Members;
+        public List<GenericParameter> GenericParameters => Type.GenericParameters;
+
+        public override string ToString()
+        {
+            return FullName;
+        }
+
+        private bool Equals(Struct other)
+        {
+            return Equals(Type, other.Type);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((Struct)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Type != null ? Type.GetHashCode() : 0;
+        }
+    }
+}

--- a/ArchUnitNETTests/ArchUnitNETTests.csproj
+++ b/ArchUnitNETTests/ArchUnitNETTests.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\TestAssembly\TestAssembly.csproj" />
     <ProjectReference Include="..\TestAssemblies\AttributeAssembly\AttributeAssembly.csproj" />
     <ProjectReference Include="..\TestAssemblies\DependencyAssembly\DependencyAssembly.csproj" />
+    <ProjectReference Include="..\TestAssemblies\FilteredDirectoryLoaderTestAssembly\FilteredDirectoryLoaderTestAssembly.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\TestAssemblies\LoaderTestAssembly\LoaderTestAssembly.csproj" />
     <ProjectReference
       Include="..\TestAssemblies\OtherLoaderTestAssembly\OtherLoaderTestAssembly.csproj" />

--- a/ArchUnitNETTests/Loader/ArchLoaderTests.cs
+++ b/ArchUnitNETTests/Loader/ArchLoaderTests.cs
@@ -4,7 +4,10 @@
 //
 // 	SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Linq;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Domain.Extensions;
 using ArchUnitNET.Loader;
 using ArchUnitNET.xUnit;
 using ArchUnitNETTests.Domain.Dependencies.Members;
@@ -95,6 +98,31 @@ namespace ArchUnitNETTests.Loader
                 .NotDependOnAnyTypesThat()
                 .ResideInAssembly(GetType().Assembly)
                 .Check(architecture);
+        }
+
+        [Fact]
+        public void UnavailableTypeTest()
+        {
+            // When loading an assembly from a file, there are situations where the assemblies dependencies are not
+            // available in the current AppDomain. This test checks that the loader does not throw an exception in this
+            // case.
+            var assemblyPath = AppDomain.CurrentDomain.BaseDirectory[
+                ..AppDomain.CurrentDomain.BaseDirectory.IndexOf(
+                    @"ArchUnitNETTests",
+                    StringComparison.InvariantCulture
+                )
+            ];
+            var architecture = new ArchLoader()
+                .LoadFilteredDirectory(
+                    assemblyPath,
+                    "FilteredDirectoryLoaderTestAssembly.dll",
+                    System.IO.SearchOption.AllDirectories
+                )
+                .Build();
+            Assert.Single(architecture.Types);
+            var loggerType = architecture.ReferencedTypes.WhereFullNameIs("Serilog.ILogger");
+            Assert.NotNull(loggerType);
+            Assert.True(loggerType is UnavailableType);
         }
     }
 }

--- a/TestAssemblies/AttributeAssembly/AttributeAssembly.csproj
+++ b/TestAssemblies/AttributeAssembly/AttributeAssembly.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>

--- a/TestAssemblies/DependencyAssembly/DependencyAssembly.csproj
+++ b/TestAssemblies/DependencyAssembly/DependencyAssembly.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>

--- a/TestAssemblies/FilteredDirectoryLoaderTestAssembly/Class1.cs
+++ b/TestAssemblies/FilteredDirectoryLoaderTestAssembly/Class1.cs
@@ -1,0 +1,13 @@
+using Serilog;
+
+namespace FilteredDirectoryLoaderTestAssembly;
+
+public class Class1
+{
+    public ILogger logger;
+
+    public Class1()
+    {
+        this.logger = new LoggerConfiguration().CreateLogger();
+    }
+}

--- a/TestAssemblies/FilteredDirectoryLoaderTestAssembly/FilteredDirectoryLoaderTestAssembly.csproj
+++ b/TestAssemblies/FilteredDirectoryLoaderTestAssembly/FilteredDirectoryLoaderTestAssembly.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Serilog" Version="4.2.0" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/TestAssemblies/FilteredDirectoryLoaderTestAssembly/FilteredDirectoryLoaderTestAssembly.sln
+++ b/TestAssemblies/FilteredDirectoryLoaderTestAssembly/FilteredDirectoryLoaderTestAssembly.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FilteredDirectoryLoaderTestAssembly", "FilteredDirectoryLoaderTestAssembly.csproj", "{8597C220-0EC2-42AF-9675-C56607614773}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8597C220-0EC2-42AF-9675-C56607614773}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8597C220-0EC2-42AF-9675-C56607614773}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8597C220-0EC2-42AF-9675-C56607614773}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8597C220-0EC2-42AF-9675-C56607614773}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B166203B-6B5B-4BE6-B945-CA9FD03A6054}
+	EndGlobalSection
+EndGlobal

--- a/TestAssemblies/LoaderTestAssembly/LoaderTestAssembly.csproj
+++ b/TestAssemblies/LoaderTestAssembly/LoaderTestAssembly.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>

--- a/TestAssemblies/OtherLoaderTestAssembly/OtherLoaderTestAssembly.csproj
+++ b/TestAssemblies/OtherLoaderTestAssembly/OtherLoaderTestAssembly.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>

--- a/TestAssemblies/VisibilityAssembly/VisibilityAssembly.csproj
+++ b/TestAssemblies/VisibilityAssembly/VisibilityAssembly.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
When assemblies are loaded by path, there are cases where a dependent type cannot be resolved because the assembly dependency is not loaded in the current application domain. In this case, we create a stub type.

Fixes #325 