### PR TITLE
Break Recursion in Resolving Generic Arguments of Nested Functions

### DIFF
--- a/ArchUnitNET/Loader/LoadTasks/AddGenericParameterDependencies.cs
+++ b/ArchUnitNET/Loader/LoadTasks/AddGenericParameterDependencies.cs
@@ -24,6 +24,7 @@ namespace ArchUnitNET.Loader.LoadTasks
         {
             foreach (var genericParameter in _type.GenericParameters)
             {
+                genericParameter.AssignDeclarer(_type);
                 foreach (var typeInstanceConstraint in genericParameter.TypeInstanceConstraints)
                 {
                     var dependency = new TypeGenericParameterTypeConstraintDependency(
@@ -41,6 +42,7 @@ namespace ArchUnitNET.Loader.LoadTasks
             {
                 foreach (var genericParameter in member.GenericParameters)
                 {
+                    genericParameter.AssignDeclarer(member);
                     foreach (var typeInstanceConstraint in genericParameter.TypeInstanceConstraints)
                     {
                         var dependency = new MemberGenericParameterTypeConstraintDependency(

--- a/TestAssemblies/DependencyAssembly/TypeDependency.cs
+++ b/TestAssemblies/DependencyAssembly/TypeDependency.cs
@@ -43,3 +43,18 @@ public class ChildClassOfGeneric : GenericBaseClass<ChildClassOfGeneric> { }
 public class ClassWithoutDependencies { }
 
 public class OtherClassWithoutDependencies { }
+
+// https://github.com/TNG/ArchUnitNET/issues/351
+class Issue351
+{
+    public void OuterFunc()
+    {
+        LocalFunc<string>();
+
+        void LocalFunc<T>()
+        {
+            var list = new List<string>();
+            list.GroupBy(x => x).ToDictionary(g => g.Key, g => (IReadOnlyCollection<T>)g.ToList());
+        }
+    }
+}


### PR DESCRIPTION
Revert change from #318 that can load on an exception for nested functions with generic parameters and add a class that correctly covers this case.