### PR TITLE
Add Workflow to Automatically Label New Issues

### DIFF
--- a/.github/workflows/label-issues.yaml
+++ b/.github/workflows/label-issues.yaml
@@ -1,0 +1,16 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "needs-triage"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
New issues should automatically be labelled with `needs-triage`