### PR TITLE
Fix assignment of MemberGenericArguments

### DIFF
--- a/ArchUnitNET/Domain/Dependencies/MethodCallDependency.cs
+++ b/ArchUnitNET/Domain/Dependencies/MethodCallDependency.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using ArchUnitNET.Loader;
 
 namespace ArchUnitNET.Domain.Dependencies
 {
@@ -9,7 +8,7 @@ namespace ArchUnitNET.Domain.Dependencies
             : base(originMember, calledMethodInstance)
         {
             TargetMember = calledMethodInstance.Member;
-            TargetMemberGenericArguments = calledMethodInstance.GenericArguments;
+            TargetMemberGenericArguments = calledMethodInstance.MemberGenericArguments;
         }
 
         public IMember TargetMember { get; }


### PR DESCRIPTION
In my opinion there where some changes in commit f80d9aa4 that led to generic arguments inside of method calls to not be detected correctly. For example if there is method inside a class which calls a method with generic arguments from a different class. Those generic arguments from the called method will not correctly show up in the dependencies.