### PR TITLE
Handle UnavailableType when creating an Attribute

### DIFF
--- a/ArchUnit.sln
+++ b/ArchUnit.sln
@@ -46,6 +46,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchUnitNET.TUnitTests", "A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InterfaceAssembly", "TestAssemblies\InterfaceAssembly\InterfaceAssembly.csproj", "{076E223C-32D3-4672-8B00-925CDBC1383E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FilteredDirectoryAssemblyAttributeAssembly", "FilteredDirectoryAssemblyAttributeAssembly\FilteredDirectoryAssemblyAttributeAssembly.csproj", "{AA695589-8CCC-4474-9A7F-01A6376C375A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -136,6 +138,10 @@ Global
 		{076E223C-32D3-4672-8B00-925CDBC1383E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{076E223C-32D3-4672-8B00-925CDBC1383E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{076E223C-32D3-4672-8B00-925CDBC1383E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA695589-8CCC-4474-9A7F-01A6376C375A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA695589-8CCC-4474-9A7F-01A6376C375A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA695589-8CCC-4474-9A7F-01A6376C375A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA695589-8CCC-4474-9A7F-01A6376C375A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,5 +154,6 @@ Global
 		{5A24529B-1794-4080-ADCC-77440BA0A0B3} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 		{E6CB8C69-25F5-4C94-8EA3-D56E444EB46B} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 		{076E223C-32D3-4672-8B00-925CDBC1383E} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
+		{AA695589-8CCC-4474-9A7F-01A6376C375A} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 	EndGlobalSection
 EndGlobal

--- a/ArchUnitNET/Loader/MonoCecilAttributeExtensions.cs
+++ b/ArchUnitNET/Loader/MonoCecilAttributeExtensions.cs
@@ -20,7 +20,12 @@ namespace ArchUnitNET.Loader
             var attributeType = typeFactory.GetOrCreateStubTypeInstanceFromTypeReference(
                 attributeTypeReference
             );
-            if (!(attributeType.Type is Attribute attribute))
+            var attribute = attributeType.Type as Attribute;
+            if (attributeType.Type is UnavailableType unavailableType)
+            {
+                attribute = new Attribute(unavailableType, null, null);
+            }
+            if (attribute == null)
             {
                 throw new ArgumentException(
                     $"Attribute type {attributeType.Type.FullName} is not an attribute."

--- a/ArchUnitNETTests/Loader/ArchLoaderTests.cs
+++ b/ArchUnitNETTests/Loader/ArchLoaderTests.cs
@@ -2,6 +2,7 @@
 extern alias OtherLoaderTestAssemblyAlias;
 
 using System;
+using System.IO;
 using System.Linq;
 using ArchUnitNET.Domain;
 using ArchUnitNET.Domain.Extensions;
@@ -132,15 +133,18 @@ namespace ArchUnitNETTests.Loader
             // When loading an assembly from a file, there are situations where the assemblies dependencies are not
             // available in the current AppDomain. This test checks that the loader does not throw an exception in this
             // case.
-            var assemblyPath = AppDomain.CurrentDomain.BaseDirectory[
+            var currentAssemblyPath = AppDomain.CurrentDomain.BaseDirectory[
                 ..AppDomain.CurrentDomain.BaseDirectory.IndexOf(
                     @"ArchUnitNETTests",
                     StringComparison.InvariantCulture
                 )
             ];
+            var assemblySearchPath = Path.Combine(
+                [currentAssemblyPath, "TestAssemblies", "FilteredDirectoryLoaderTestAssembly"]
+            );
             var architecture = new ArchLoader()
                 .LoadFilteredDirectory(
-                    assemblyPath,
+                    assemblySearchPath,
                     "FilteredDirectoryLoaderTestAssembly.dll",
                     System.IO.SearchOption.AllDirectories
                 )

--- a/FilteredDirectoryAssemblyAttributeAssembly/AssemblyAttribute.cs
+++ b/FilteredDirectoryAssemblyAttributeAssembly/AssemblyAttribute.cs
@@ -1,0 +1,4 @@
+﻿namespace FilteredDirectoryAssemblyAttributeAssembly;
+
+[AttributeUsage(AttributeTargets.Assembly)]
+public class AssemblyAttribute : Attribute { }

--- a/FilteredDirectoryAssemblyAttributeAssembly/FilteredDirectoryAssemblyAttributeAssembly.csproj
+++ b/FilteredDirectoryAssemblyAttributeAssembly/FilteredDirectoryAssemblyAttributeAssembly.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/TestAssemblies/FilteredDirectoryLoaderTestAssembly/Class1.cs
+++ b/TestAssemblies/FilteredDirectoryLoaderTestAssembly/Class1.cs
@@ -1,5 +1,7 @@
 using Serilog;
 
+[assembly: FilteredDirectoryAssemblyAttributeAssembly.AssemblyAttribute]
+
 namespace FilteredDirectoryLoaderTestAssembly;
 
 public class Class1

--- a/TestAssemblies/FilteredDirectoryLoaderTestAssembly/FilteredDirectoryLoaderTestAssembly.csproj
+++ b/TestAssemblies/FilteredDirectoryLoaderTestAssembly/FilteredDirectoryLoaderTestAssembly.csproj
@@ -10,4 +10,11 @@
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\FilteredDirectoryAssemblyAttributeAssembly\FilteredDirectoryAssemblyAttributeAssembly.csproj">
+      <!-- Do not copy the referenced assembly to the output directory -->
+      <!-- in order to test handling of unavailable types as attribute assemblies -->
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
As a fix for #398, we wrap UnavailableType instances in Attribute instances when creating an Attribute of a type whose Assembly is not available.