### PR TITLE
Comprehensive In-Memory Caching (fix #404)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,4 @@
 name: build
-run-name: Build and test
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/ArchUnitNET/Domain/ArchLoaderCacheConfig.cs
+++ b/ArchUnitNET/Domain/ArchLoaderCacheConfig.cs
@@ -1,0 +1,52 @@
+﻿namespace ArchUnitNET.Domain
+{
+    /// <summary>
+    /// Configuration options for the ArchLoader caching mechanism
+    /// </summary>
+    public sealed class ArchLoaderCacheConfig
+    {
+        /// <summary>
+        /// Creates a new instance with default settings (caching enabled, file-based invalidation enabled)
+        /// </summary>
+        public ArchLoaderCacheConfig()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets whether caching is enabled. Default is true.
+        /// </summary>
+        public bool CachingEnabled { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether to use file-based invalidation (hash + timestamp + size checking).
+        /// Default is true. When false, only module names are used for cache keys.
+        /// </summary>
+        public bool UseFileBasedInvalidation { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets an optional user-provided cache key for fine-grained control.
+        /// When set, this key is included in the cache key computation.
+        /// </summary>
+        public string UserCacheKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to include the ArchUnitNET version in cache invalidation.
+        /// Default is true.
+        /// </summary>
+        public bool IncludeVersionInCacheKey { get; set; } = true;
+
+        /// <summary>
+        /// Creates a copy of this configuration
+        /// </summary>
+        public ArchLoaderCacheConfig Clone()
+        {
+            return new ArchLoaderCacheConfig
+            {
+                CachingEnabled = CachingEnabled,
+                UseFileBasedInvalidation = UseFileBasedInvalidation,
+                UserCacheKey = UserCacheKey,
+                IncludeVersionInCacheKey = IncludeVersionInCacheKey
+            };
+        }
+    }
+}

--- a/ArchUnitNET/Domain/ArchitectureCacheManager.cs
+++ b/ArchUnitNET/Domain/ArchitectureCacheManager.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ArchUnitNET.Domain
+{
+    /// <summary>
+    /// Enhanced caching manager for Architecture instances with automatic invalidation support
+    /// </summary>
+    public class ArchitectureCacheManager
+    {
+        private readonly ConcurrentDictionary<EnhancedCacheKey, CachedArchitecture> _cache =
+            new ConcurrentDictionary<EnhancedCacheKey, CachedArchitecture>();
+
+        private static readonly Lazy<ArchitectureCacheManager> _instance =
+            new Lazy<ArchitectureCacheManager>(() => new ArchitectureCacheManager());
+
+        private static readonly string ArchUnitNetVersion =
+            typeof(Architecture).Assembly.GetName().Version?.ToString() ?? "unknown";
+
+        protected ArchitectureCacheManager() { }
+
+        public static ArchitectureCacheManager Instance => _instance.Value;
+
+        /// <summary>
+        /// Try to get a cached architecture. Returns null if not found or if cache is invalid.
+        /// </summary>
+        public Architecture TryGetArchitecture(
+            ArchitectureCacheKey baseCacheKey,
+            IEnumerable<AssemblyMetadata> assemblyMetadata,
+            ArchLoaderCacheConfig config)
+        {
+            if (config == null || !config.CachingEnabled)
+            {
+                return null;
+            }
+
+            var assemblyMetadatas = assemblyMetadata as AssemblyMetadata[] ?? assemblyMetadata.ToArray();
+            var enhancedKey = new EnhancedCacheKey(
+                baseCacheKey,
+                config.UseFileBasedInvalidation ? assemblyMetadatas : null,
+                config.UserCacheKey,
+                config.IncludeVersionInCacheKey ? ArchUnitNetVersion : null
+            );
+
+            if (_cache.TryGetValue(enhancedKey, out var cached))
+            {
+                if (config.UseFileBasedInvalidation && cached.AssemblyMetadata != null)
+                {
+                    var currentMetadata = assemblyMetadatas?.ToList();
+                    if (!AreAssembliesUnchanged(cached.AssemblyMetadata, currentMetadata))
+                    {
+                        _cache.TryRemove(enhancedKey, out _);
+                        return null;
+                    }
+                }
+
+                return cached.Architecture;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Add an architecture to the cache
+        /// </summary>
+        public bool Add(
+            ArchitectureCacheKey baseCacheKey,
+            Architecture architecture,
+            IEnumerable<AssemblyMetadata> assemblyMetadata,
+            ArchLoaderCacheConfig config)
+        {
+            if (config == null || !config.CachingEnabled)
+            {
+                return false;
+            }
+
+            var assemblyMetadatas = assemblyMetadata as AssemblyMetadata[] ?? assemblyMetadata.ToArray();
+            var enhancedKey = new EnhancedCacheKey(
+                baseCacheKey,
+                config.UseFileBasedInvalidation ? assemblyMetadatas : null,
+                config.UserCacheKey,
+                config.IncludeVersionInCacheKey ? ArchUnitNetVersion : null
+            );
+
+            var cached = new CachedArchitecture
+            {
+                Architecture = architecture,
+                AssemblyMetadata = config.UseFileBasedInvalidation
+                    ? assemblyMetadatas?.ToList()
+                    : null,
+                CachedAt = DateTime.UtcNow
+            };
+
+            return _cache.TryAdd(enhancedKey, cached);
+        }
+
+        /// <summary>
+        /// Clear all cached architectures
+        /// </summary>
+        public void Clear() => _cache.Clear();
+
+        /// <summary>
+        /// Get the number of cached architectures
+        /// </summary>
+        public int Count => _cache.Count;
+
+        private static bool AreAssembliesUnchanged(
+            List<AssemblyMetadata> cached,
+            List<AssemblyMetadata> current)
+        {
+            if (cached == null || current == null)
+                return cached == current;
+
+            if (cached.Count != current.Count)
+                return false;
+
+            var cachedDict = cached.ToDictionary(m => m.FilePath, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var currentMeta in current)
+            {
+                if (!cachedDict.TryGetValue(currentMeta.FilePath, out var cachedMeta))
+                    return false;
+
+                if (!cachedMeta.Equals(currentMeta))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private class CachedArchitecture
+        {
+            public Architecture Architecture { get; set; }
+            public List<AssemblyMetadata> AssemblyMetadata { get; set; }
+            public DateTime CachedAt { get; set; }
+        }
+
+        private class EnhancedCacheKey : IEquatable<EnhancedCacheKey>
+        {
+            private readonly ArchitectureCacheKey _baseCacheKey;
+            private readonly List<AssemblyMetadata> _assemblyMetadata;
+            private readonly string _userCacheKey;
+            private readonly string _version;
+            private readonly int _hashCode;
+
+            public EnhancedCacheKey(
+                ArchitectureCacheKey baseCacheKey,
+                IEnumerable<AssemblyMetadata> assemblyMetadata,
+                string userCacheKey,
+                string version)
+            {
+                _baseCacheKey = baseCacheKey ?? throw new ArgumentNullException(nameof(baseCacheKey));
+                _assemblyMetadata = assemblyMetadata?.OrderBy(m => m.FilePath, StringComparer.OrdinalIgnoreCase).ToList();
+                _userCacheKey = userCacheKey;
+                _version = version;
+                _hashCode = ComputeHashCode();
+            }
+
+            private int ComputeHashCode()
+            {
+                unchecked
+                {
+                    var hash = _baseCacheKey.GetHashCode();
+                    hash = (hash * 397) ^ (_userCacheKey?.GetHashCode() ?? 0);
+                    hash = (hash * 397) ^ (_version?.GetHashCode() ?? 0);
+
+                    if (_assemblyMetadata != null)
+                    {
+                        foreach (var metadata in _assemblyMetadata)
+                        {
+                            hash = (hash * 397) ^ metadata.GetHashCode();
+                        }
+                    }
+
+                    return hash;
+                }
+            }
+
+            public bool Equals(EnhancedCacheKey other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+
+                if (!_baseCacheKey.Equals(other._baseCacheKey))
+                    return false;
+
+                if (_userCacheKey != other._userCacheKey)
+                    return false;
+
+                if (_version != other._version)
+                    return false;
+
+                if (_assemblyMetadata == null && other._assemblyMetadata == null)
+                    return true;
+
+                if (_assemblyMetadata == null || other._assemblyMetadata == null)
+                    return false;
+
+                if (_assemblyMetadata.Count != other._assemblyMetadata.Count)
+                    return false;
+
+                return _assemblyMetadata.SequenceEqual(other._assemblyMetadata);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is EnhancedCacheKey other && Equals(other);
+            }
+
+            public override int GetHashCode() => _hashCode;
+        }
+    }
+}

--- a/ArchUnitNET/Domain/AssemblyMetadata.cs
+++ b/ArchUnitNET/Domain/AssemblyMetadata.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace ArchUnitNET.Domain
+{
+    /// <summary>
+    /// Tracks metadata for an assembly file to detect changes
+    /// </summary>
+    public sealed class AssemblyMetadata : IEquatable<AssemblyMetadata>
+    {
+        public string FilePath { get; }
+        public string FileHash { get; }
+        public DateTime LastWriteTimeUtc { get; }
+        public long FileSize { get; }
+
+        public AssemblyMetadata(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                throw new ArgumentException("File path cannot be null or empty", nameof(filePath));
+            }
+
+            if (!File.Exists(filePath))
+            {
+                throw new FileNotFoundException($"Assembly file not found: {filePath}", filePath);
+            }
+
+            FilePath = Path.GetFullPath(filePath);
+            var fileInfo = new FileInfo(FilePath);
+            LastWriteTimeUtc = fileInfo.LastWriteTimeUtc;
+            FileSize = fileInfo.Length;
+            FileHash = ComputeFileHash(FilePath);
+        }
+
+        private static string ComputeFileHash(string filePath)
+        {
+            using (var sha256 = SHA256.Create())
+            using (var stream = File.OpenRead(filePath))
+            {
+                var hash = sha256.ComputeHash(stream);
+                return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+            }
+        }
+
+        public bool Equals(AssemblyMetadata other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return string.Equals(FilePath, other.FilePath, StringComparison.OrdinalIgnoreCase)
+                && FileHash == other.FileHash
+                && LastWriteTimeUtc.Equals(other.LastWriteTimeUtc)
+                && FileSize == other.FileSize;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((AssemblyMetadata)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = StringComparer.OrdinalIgnoreCase.GetHashCode(FilePath ?? string.Empty);
+                hashCode = (hashCode * 397) ^ (FileHash?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ LastWriteTimeUtc.GetHashCode();
+                hashCode = (hashCode * 397) ^ FileSize.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"AssemblyMetadata(Path={FilePath}, Hash={FileHash?.Substring(0, 8)}..., Size={FileSize}, Modified={LastWriteTimeUtc})";
+        }
+    }
+}

--- a/ArchUnitNETTests/Loader/ArchLoaderCacheTests.cs
+++ b/ArchUnitNETTests/Loader/ArchLoaderCacheTests.cs
@@ -1,0 +1,177 @@
+﻿using ArchUnitNET.Domain;
+using ArchUnitNET.Loader;
+using System.Diagnostics;
+using Xunit;
+
+namespace ArchUnitNETTests.Loader
+{
+    public class ArchLoaderCacheTests
+    {
+        [Fact]
+        public void LoadingSameAssemblyTwiceReturnsCachedArchitecture()
+        {
+            // Arrange
+            var assembly = typeof(Architecture).Assembly;
+
+            // Act
+            var architecture1 = new ArchLoader().LoadAssemblies(assembly).Build();
+            var architecture2 = new ArchLoader().LoadAssemblies(assembly).Build();
+
+            // Assert - Should return the same cached instance
+            Assert.Same(architecture1, architecture2);
+        }
+
+        [Fact]
+        public void LoadingSameAssemblyTwiceIsFasterOnSecondLoad()
+        {
+            // Arrange
+            var assembly = typeof(Architecture).Assembly;
+            ArchitectureCache.Instance.Clear(); // Clear cache to ensure fair timing
+            ArchitectureCacheManager.Instance.Clear();
+
+            // Act
+            var sw1 = Stopwatch.StartNew();
+            var architecture1 = new ArchLoader().LoadAssemblies(assembly).Build();
+            sw1.Stop();
+
+            var sw2 = Stopwatch.StartNew();
+            var architecture2 = new ArchLoader().LoadAssemblies(assembly).Build();
+            sw2.Stop();
+
+            // Assert - Second load should be significantly faster (at least 50% faster)
+            Assert.True(
+                sw2.ElapsedMilliseconds < sw1.ElapsedMilliseconds * 0.5,
+                $"Expected second load ({sw2.ElapsedMilliseconds}ms) to be at least 50% faster than first load ({sw1.ElapsedMilliseconds}ms)"
+            );
+            Assert.Same(architecture1, architecture2);
+        }
+
+        [Fact]
+        public void LoadingMultipleAssembliesReturnsCachedArchitecture()
+        {
+            // Arrange - Use two truly different assemblies
+            var assembly1 = typeof(Architecture).Assembly; // ArchUnitNET
+            var assembly2 = typeof(ArchLoaderCacheTests).Assembly; // ArchUnitNETTests
+
+            // Act
+            var architecture1 = new ArchLoader()
+                .LoadAssemblies(assembly1, assembly2)
+                .Build();
+            var architecture2 = new ArchLoader()
+                .LoadAssemblies(assembly1, assembly2)
+                .Build();
+
+            // Assert
+            Assert.Same(architecture1, architecture2);
+        }
+
+        [Fact]
+        public void LoadingAssembliesInDifferentOrderReturnsSameCachedArchitecture()
+        {
+            // Arrange - Use two truly different assemblies
+            var assembly1 = typeof(Architecture).Assembly; // ArchUnitNET
+            var assembly2 = typeof(ArchLoaderCacheTests).Assembly; // ArchUnitNETTests
+
+            // Act - Load in different order
+            var architecture1 = new ArchLoader()
+                .LoadAssemblies(assembly1, assembly2)
+                .Build();
+            var architecture2 = new ArchLoader()
+                .LoadAssemblies(assembly2, assembly1)
+                .Build();
+
+            // Assert - Should return same cached instance regardless of order
+            Assert.Same(architecture1, architecture2);
+        }
+
+        [Fact]
+        public void LoadingDifferentAssembliesReturnsDifferentArchitectures()
+        {
+            // Arrange - Use two truly different assemblies
+            var assembly1 = typeof(Architecture).Assembly; // ArchUnitNET
+            var assembly2 = typeof(ArchLoaderCacheTests).Assembly; // ArchUnitNETTests
+
+            // Act
+            var architecture1 = new ArchLoader().LoadAssemblies(assembly1).Build();
+            var architecture2 = new ArchLoader().LoadAssemblies(assembly2).Build();
+
+            // Assert - Different assemblies should return different architectures
+            Assert.NotSame(architecture1, architecture2);
+        }
+
+        [Fact]
+        public void LoadingWithNamespaceFilterReturnsCachedArchitecture()
+        {
+            // Arrange
+            var assembly = typeof(Architecture).Assembly;
+            var namespaceName = "ArchUnitNET.Domain";
+
+            // Act
+            var architecture1 = new ArchLoader()
+                .LoadNamespacesWithinAssembly(assembly, namespaceName)
+                .Build();
+            var architecture2 = new ArchLoader()
+                .LoadNamespacesWithinAssembly(assembly, namespaceName)
+                .Build();
+
+            // Assert
+            Assert.Same(architecture1, architecture2);
+        }
+
+        [Fact]
+        public void LoadingDifferentNamespacesReturnsDifferentArchitectures()
+        {
+            // Arrange
+            var assembly = typeof(Architecture).Assembly;
+
+            // Act
+            var architecture1 = new ArchLoader()
+                .LoadNamespacesWithinAssembly(assembly, "ArchUnitNET.Domain")
+                .Build();
+            var architecture2 = new ArchLoader()
+                .LoadNamespacesWithinAssembly(assembly, "ArchUnitNET.Loader")
+                .Build();
+
+            // Assert - Different namespace filters should return different architectures
+            Assert.NotSame(architecture1, architecture2);
+        }
+
+        [Fact]
+        public void ClearingCacheForcesReloadOnNextBuild()
+        {
+            // Arrange
+            var assembly = typeof(Architecture).Assembly;
+            var architecture1 = new ArchLoader().LoadAssemblies(assembly).Build();
+
+            // Act
+            ArchitectureCache.Instance.Clear();
+            ArchitectureCacheManager.Instance.Clear();
+            var architecture2 = new ArchLoader().LoadAssemblies(assembly).Build();
+
+            // Assert - After clearing cache, should get a new instance
+            Assert.NotSame(architecture1, architecture2);
+
+            // But loading again should return cached version
+            var architecture3 = new ArchLoader().LoadAssemblies(assembly).Build();
+            Assert.Same(architecture2, architecture3);
+        }
+
+        [Fact]
+        public void LoadingAssembliesIncludingDependenciesUsesCaching()
+        {
+            // Arrange
+            var assembly = typeof(Architecture).Assembly;
+
+            // Act
+            var architecture1 = new ArchLoader()
+                .LoadAssembliesIncludingDependencies(assembly)
+                .Build();
+            var architecture2 = new ArchLoader()
+                .LoadAssembliesIncludingDependencies(assembly)
+                .Build();
+
+            // Assert
+            Assert.Same(architecture1, architecture2);
+        }
+    }
+}

--- a/ArchUnitNETTests/Loader/ArchLoaderTests.cs
+++ b/ArchUnitNETTests/Loader/ArchLoaderTests.cs
@@ -1,18 +1,16 @@
 ﻿extern alias LoaderTestAssemblyAlias;
 extern alias OtherLoaderTestAssemblyAlias;
-
-using System;
-using System.IO;
-using System.Linq;
 using ArchUnitNET.Domain;
 using ArchUnitNET.Domain.Extensions;
 using ArchUnitNET.Loader;
 using ArchUnitNET.xUnit;
 using ArchUnitNETTests.Domain.Dependencies.Members;
+using System;
+using System.IO;
+using System.Linq;
 using Xunit;
 using static ArchUnitNET.Fluent.ArchRuleDefinition;
 using static ArchUnitNETTests.StaticTestArchitectures;
-
 using DuplicateClass = LoaderTestAssemblyAlias::DuplicateClassAcrossAssemblies.DuplicateClass;
 using OtherDuplicateClass = OtherLoaderTestAssemblyAlias::DuplicateClassAcrossAssemblies.DuplicateClass;
 
@@ -153,6 +151,110 @@ namespace ArchUnitNETTests.Loader
             var loggerType = architecture.ReferencedTypes.WhereFullNameIs("Serilog.ILogger");
             Assert.NotNull(loggerType);
             Assert.True(loggerType is UnavailableType);
+        }
+
+        [Fact]
+        public void WithoutCachingDisablesCaching()
+        {
+            // Arrange & Act
+            var architecture1 = new ArchLoader()
+                .WithoutCaching()
+                .LoadAssemblies(typeof(Architecture).Assembly)
+                .Build();
+
+            var architecture2 = new ArchLoader()
+                .WithoutCaching()
+                .LoadAssemblies(typeof(Architecture).Assembly)
+                .Build();
+
+            // Assert - Without caching, should get different instances
+            Assert.NotSame(architecture1, architecture2);
+        }
+
+        [Fact]
+        public void WithUserCacheKeySetsCustomCacheKey()
+        {
+            // Arrange
+            var assembly = typeof(Architecture).Assembly;
+
+            // Act
+            var architecture1 = new ArchLoader()
+                .WithUserCacheKey("key1")
+                .LoadAssemblies(assembly)
+                .Build();
+
+            var architecture2 = new ArchLoader()
+                .WithUserCacheKey("key1")
+                .LoadAssemblies(assembly)
+                .Build();
+
+            var architecture3 = new ArchLoader()
+                .WithUserCacheKey("key2")
+                .LoadAssemblies(assembly)
+                .Build();
+
+            // Assert - Same cache key should return same instance
+            Assert.Same(architecture1, architecture2);
+            // Different cache key should return different instance
+            Assert.NotSame(architecture1, architecture3);
+        }
+
+        [Fact]
+        public void FluentAPIChainingWorks()
+        {
+            // Arrange & Act
+            var architecture = new ArchLoader()
+                .WithUserCacheKey("test-chain")
+                .LoadAssemblies(typeof(Architecture).Assembly)
+                .Build();
+
+            // Assert
+            Assert.NotNull(architecture);
+            Assert.NotEmpty(architecture.Types);
+        }
+
+        [Fact]
+        public void WithCacheConfigThrowsOnNullConfig()
+        {
+            // Arrange
+            var loader = new ArchLoader();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => loader.WithCacheConfig(null));
+        }
+
+        [Fact]
+        public void WithCacheConfigClonesConfigToPreventExternalMutation()
+        {
+            // Arrange
+            var config = new ArchLoaderCacheConfig
+            {
+                CachingEnabled = true,
+                UseFileBasedInvalidation = true,
+                UserCacheKey = "original-key"
+            };
+
+            var assembly = typeof(Architecture).Assembly;
+
+            // Act
+            var architecture1 = new ArchLoader()
+                .WithCacheConfig(config)
+                .LoadAssemblies(assembly)
+                .Build();
+
+            // Mutate the original config
+            config.UserCacheKey = "modified-key";
+            config.CachingEnabled = false;
+
+            // Build again with a new loader using the SAME config object
+            var architecture2 = new ArchLoader()
+                .WithCacheConfig(config)
+                .LoadAssemblies(assembly)
+                .Build();
+
+            // Assert - The first architecture should still be cached with original key
+            // and the second should use the modified key, so they should be different
+            Assert.NotSame(architecture1, architecture2);
         }
     }
 }


### PR DESCRIPTION
### How It Works
[Fix this](https://github.com/TNG/ArchUnitNET/issues/404)
When you call `new ArchLoader().LoadAssemblies(...).Build()`, ArchUnitNET automatically:

1. **Creates a cache key** based on the modules being loaded and any namespace filters applied
2. **Checks the cache** for a previously loaded Architecture instance matching this key
3. **Returns the cached instance** if found, or loads and caches a new instance if not

This means that loading the same assemblies multiple times (even with different `ArchLoader` instances) will reuse the cached `Architecture` object, providing **dramatic performance improvements**.

### Usage Examples

**Basic usage (automatic caching with file-based invalidation):**
```csharp
var arch = new ArchLoader()
    .LoadAssemblies(assembly)
    .Build(); // Automatically cached with invalidation
```

**Custom cache key for test isolation:**
```csharp
var arch = new ArchLoader()
    .WithUserCacheKey("test-run-1")
    .LoadAssemblies(assembly)
    .Build();
```

**Disable caching for specific scenarios:**
```csharp
var arch = new ArchLoader()
    .WithoutCaching()
    .LoadAssemblies(assembly)
    .Build();
```

**Advanced configuration (config is cloned internally):**
```csharp
var config = new ArchLoaderCacheConfig
{
    CachingEnabled = true,
    UseFileBasedInvalidation = true, // Check file changes
    UserCacheKey = "integration-tests",
    IncludeVersionInCacheKey = true // Invalidate on version change
};

var arch = new ArchLoader()
    .WithCacheConfig(config)
    .LoadAssemblies(assembly)
    .Build();

// Safe: modifying config after passing it won't affect the ArchLoader
config.UserCacheKey = "different-key";
```