### PR TITLE
Add IOrderedCondition

### DIFF
--- a/ArchUnitNET/Domain/Extensions/EnumerableExtensions.cs
+++ b/ArchUnitNET/Domain/Extensions/EnumerableExtensions.cs
@@ -62,5 +62,25 @@ namespace ArchUnitNET.Domain.Extensions
                 (arg.Item1, arg.Item2 is Type type ? architecture.GetITypeOfType(type) : arg.Item2)
             );
         }
+
+        /// <summary>
+        ///   Creates a lookup function for the given collection of elements.
+        ///   For smaller collections, it uses the Contains method of the collection directly.
+        ///   For larger collections, it creates a HashSet for O(1) average time complexity lookups.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The type of elements in the collection.</typeparam>
+        ///
+        /// <param name="elements">The collection of elements to create a lookup function for.</param>
+        ///
+        /// <returns>A function that checks if an element is in the collection.</returns>
+        public static Func<T, bool> CreateLookupFn<T>(ICollection<T> elements)
+        {
+            if (elements.Count < 20)
+            {
+                return elements.Contains;
+            }
+            return new HashSet<T>(elements).Contains;
+        }
     }
 }

--- a/ArchUnitNET/Domain/UnavailableType.cs
+++ b/ArchUnitNET/Domain/UnavailableType.cs
@@ -42,7 +42,7 @@ namespace ArchUnitNET.Domain
             return FullName;
         }
 
-        private bool Equals(Struct other)
+        private bool Equals(UnavailableType other)
         {
             return Equals(Type, other.Type);
         }

--- a/ArchUnitNET/Fluent/Conditions/ArchitectureCondition.cs
+++ b/ArchUnitNET/Fluent/Conditions/ArchitectureCondition.cs
@@ -15,51 +15,11 @@ namespace ArchUnitNET.Fluent.Conditions
         > _condition;
 
         public ArchitectureCondition(
-            Func<TRuleType, Architecture, bool> condition,
-            string description,
-            string failDescription
-        )
-        {
-            _condition = (ruleTypes, architecture) =>
-                ruleTypes.Select(type => new ConditionResult(
-                    type,
-                    condition(type, architecture),
-                    failDescription
-                ));
-            Description = description;
-        }
-
-        public ArchitectureCondition(
-            Func<TRuleType, Architecture, ConditionResult> condition,
-            string description
-        )
-        {
-            _condition = (ruleTypes, architecture) =>
-                ruleTypes.Select(type => condition(type, architecture));
-            Description = description;
-        }
-
-        public ArchitectureCondition(
             Func<IEnumerable<TRuleType>, Architecture, IEnumerable<ConditionResult>> condition,
             string description
         )
         {
             _condition = condition;
-            Description = description;
-        }
-
-        public ArchitectureCondition(
-            Func<TRuleType, Architecture, bool> condition,
-            Func<TRuleType, Architecture, string> dynamicFailDescription,
-            string description
-        )
-        {
-            _condition = (ruleTypes, architecture) =>
-                ruleTypes.Select(type => new ConditionResult(
-                    type,
-                    condition(type, architecture),
-                    dynamicFailDescription(type, architecture)
-                ));
             Description = description;
         }
 

--- a/ArchUnitNET/Fluent/Conditions/ExistsCondition.cs
+++ b/ArchUnitNET/Fluent/Conditions/ExistsCondition.cs
@@ -4,7 +4,7 @@ using ArchUnitNET.Domain;
 
 namespace ArchUnitNET.Fluent.Conditions
 {
-    public class ExistsCondition<TRuleType> : ICondition<TRuleType>
+    public class ExistsCondition<TRuleType> : IOrderedCondition<TRuleType>
         where TRuleType : ICanBeAnalyzed
     {
         private readonly bool _valueIfExists;

--- a/ArchUnitNET/Fluent/Conditions/IOrderedCondition.cs
+++ b/ArchUnitNET/Fluent/Conditions/IOrderedCondition.cs
@@ -1,0 +1,7 @@
+using ArchUnitNET.Domain;
+
+namespace ArchUnitNET.Fluent.Conditions
+{
+    public interface IOrderedCondition<in TRuleType> : ICondition<TRuleType>
+        where TRuleType : ICanBeAnalyzed { }
+}

--- a/ArchUnitNET/Fluent/Conditions/OrderedArchitectureCondition.cs
+++ b/ArchUnitNET/Fluent/Conditions/OrderedArchitectureCondition.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ArchUnitNET.Domain;
+
+namespace ArchUnitNET.Fluent.Conditions
+{
+    public class OrderedArchitectureCondition<TRuleType>
+        : ArchitectureCondition<TRuleType>,
+            IOrderedCondition<TRuleType>
+        where TRuleType : ICanBeAnalyzed
+    {
+        public OrderedArchitectureCondition(
+            Func<TRuleType, Architecture, bool> condition,
+            string description,
+            string failDescription
+        )
+            : base(
+                (ruleTypes, architecture) =>
+                    ruleTypes.Select(type => new ConditionResult(
+                        type,
+                        condition(type, architecture),
+                        failDescription
+                    )),
+                description
+            ) { }
+
+        public OrderedArchitectureCondition(
+            Func<TRuleType, Architecture, bool> condition,
+            Func<TRuleType, Architecture, string> dynamicFailDescription,
+            string description
+        )
+            : base(
+                (ruleTypes, architecture) =>
+                    ruleTypes.Select(type => new ConditionResult(
+                        type,
+                        condition(type, architecture),
+                        dynamicFailDescription(type, architecture)
+                    )),
+                description
+            ) { }
+
+        public OrderedArchitectureCondition(
+            Func<TRuleType, Architecture, ConditionResult> condition,
+            string description
+        )
+            : base(
+                (ruleTypes, architecture) =>
+                    ruleTypes.Select(type => condition(type, architecture)),
+                description
+            ) { }
+
+        public OrderedArchitectureCondition(
+            Func<IEnumerable<TRuleType>, Architecture, IEnumerable<ConditionResult>> condition,
+            string description
+        )
+            : base(condition, description) { }
+    }
+}

--- a/ArchUnitNET/Fluent/Conditions/SimpleCondition.cs
+++ b/ArchUnitNET/Fluent/Conditions/SimpleCondition.cs
@@ -5,7 +5,7 @@ using ArchUnitNET.Domain;
 
 namespace ArchUnitNET.Fluent.Conditions
 {
-    public class SimpleCondition<TRuleType> : ICondition<TRuleType>
+    public class SimpleCondition<TRuleType> : IOrderedCondition<TRuleType>
         where TRuleType : ICanBeAnalyzed
     {
         private readonly Func<TRuleType, ConditionResult> _condition;

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/TypeConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/TypeConditionsDefinition.cs
@@ -625,7 +625,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
                 (current, asm) => current + " or \"" + asm.FullName + "\""
             );
 
-            return new ArchitectureCondition<TRuleType>(
+            return new OrderedArchitectureCondition<TRuleType>(
                 Condition,
                 (type, architecture) => "does reside in " + type.Assembly.FullName,
                 description
@@ -1247,7 +1247,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
                 (current, asm) => current + " or \"" + asm.FullName + "\""
             );
 
-            return new ArchitectureCondition<TRuleType>(
+            return new OrderedArchitectureCondition<TRuleType>(
                 Condition,
                 (type, architecture) => "does reside in " + type.Assembly.FullName,
                 description


### PR DESCRIPTION
We add a sub-interface of IOrderedCondition, that has the semantic requirement that the returned IEnumerable has the same ordering as the given IEnumerable. This leads to improved performance since the results no longer have to be sorted to their rule types in all cases where only ordered conditions are used.