### PR TITLE
Record method call generic argument types as dependencies

### DIFF
--- a/ArchUnitNET/Loader/LoadTasks/AddMethodDependencies.cs
+++ b/ArchUnitNET/Loader/LoadTasks/AddMethodDependencies.cs
@@ -164,8 +164,6 @@ namespace ArchUnitNET.Loader.LoadTasks
 
             bodyTypes.AddRange(methodDefinition.GetBodyTypes(_typeFactory).ToList());
 
-            bodyTypes.AddRange(methodDefinition.GetGenericArguments(_typeFactory).ToList());
-
             var castTypes = methodDefinition.GetCastTypes(_typeFactory).ToList();
 
             var typeCheckTypes = methodDefinition.GetTypeCheckTypes(_typeFactory).ToList();
@@ -260,7 +258,16 @@ namespace ArchUnitNET.Loader.LoadTasks
             )
             {
                 visitedMethodReferences.Add(calledMethodReference);
-                bodyTypes.AddRange(calledMethodReference.GetGenericArguments(_typeFactory));
+
+                var calledType = _typeFactory.GetOrCreateStubTypeInstanceFromTypeReference(
+                    calledMethodReference.DeclaringType
+                );
+                var calledMethodMember = _typeFactory.GetOrCreateMethodMemberFromMethodReference(
+                    calledType,
+                    calledMethodReference
+                );
+
+                bodyTypes.AddRange(calledMethodMember.MemberGenericArguments);
 
                 if (calledMethodReference.IsCompilerGenerated())
                 {
@@ -317,14 +324,6 @@ namespace ArchUnitNET.Loader.LoadTasks
                 }
                 else
                 {
-                    var calledType = _typeFactory.GetOrCreateStubTypeInstanceFromTypeReference(
-                        calledMethodReference.DeclaringType
-                    );
-                    var calledMethodMember =
-                        _typeFactory.GetOrCreateMethodMemberFromMethodReference(
-                            calledType,
-                            calledMethodReference
-                        );
                     yield return calledMethodMember;
                 }
             }

--- a/ArchUnitNET/Loader/MonoCecilMemberExtensions.cs
+++ b/ArchUnitNET/Loader/MonoCecilMemberExtensions.cs
@@ -153,25 +153,6 @@ namespace ArchUnitNET.Loader
         }
 
         [NotNull]
-        internal static IEnumerable<ITypeInstance<IType>> GetGenericArguments(
-            this MethodReference method,
-            TypeFactory typeFactory
-        )
-        {
-            return method is GenericInstanceMethod genericInstanceMethod
-                ? genericInstanceMethod
-                    .GenericArguments.Select(argument =>
-                    {
-                        var typeReference = argument.GetElementType();
-                        return typeFactory.GetOrCreateStubTypeInstanceFromTypeReference(
-                            typeReference
-                        );
-                    })
-                    .Distinct()
-                : Enumerable.Empty<ITypeInstance<IType>>();
-        }
-
-        [NotNull]
         internal static IEnumerable<ITypeInstance<IType>> GetBodyTypes(
             this MethodDefinition methodDefinition,
             TypeFactory typeFactory

--- a/ArchUnitNETTests/Dependencies/GenericMemberDependenciesTests.cs
+++ b/ArchUnitNETTests/Dependencies/GenericMemberDependenciesTests.cs
@@ -48,7 +48,7 @@ namespace ArchUnitNETTests.Dependencies
         }
     }
 
-    public class ClassWithGenericMethodCall
+    internal class ClassWithGenericMethodCall
     {
         public void OuterFunc()
         {


### PR DESCRIPTION
Resolve an issue where generic arguments in method calls are not considered dependencies.

The helps validate modular architecture, especially for dealing with ioc containers where the types are all generic arguments.
e.g. 
`services.AddTransient<IMyService, MyService>();`
`serviceProvider.Resolve<IMyService>()`