### PR TITLE
Adjust renovate config to disable minor updates for TUnit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -91,6 +91,22 @@
       "allowedVersions": "4.x"
     },
     {
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchFileNames": [
+        "ArchUnitNET.TUnitTests/ArchUnitNET.TUnitTests.csproj"
+      ],
+      "matchPackageNames": [
+        "TUnit{/,}**"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "enabled": false
+    },
+    {
       "matchDepNames": [
         "dotnet-sdk"
       ],


### PR DESCRIPTION
Adjust renovate config to disable minor updates for TUnit because of breaking changes causing the test pipelines to fail.