### PR TITLE
Make AreStatic/AreNotStatic agree with BeStatic/NotBeStatic on unknown state

### DIFF
--- a/ArchUnitNET/Fluent/Syntax/Elements/Members/MemberPredicatesDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Members/MemberPredicatesDefinition.cs
@@ -28,7 +28,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members
         public static IPredicate<T> AreStatic()
         {
             return new SimplePredicate<T>(
-                member => member.IsStatic.HasValue && member.IsStatic.Value,
+                member => !member.IsStatic.HasValue || member.IsStatic.Value,
                 "are static"
             );
         }
@@ -70,7 +70,7 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Members
         public static IPredicate<T> AreNotStatic()
         {
             return new SimplePredicate<T>(
-                member => member.IsStatic.HasValue && !member.IsStatic.Value,
+                member => !member.IsStatic.HasValue || !member.IsStatic.Value,
                 "are not static"
             );
         }


### PR DESCRIPTION
IMember.IsStatic is null for stub members, i.e. members built from a MethodReference or FieldReference rather than a definition. The two member predicates were the only two of the 24 HasValue guards under Elements/ written as "HasValue &&" rather than "!HasValue ||", so for such a member BeStatic and NotBeStatic both passed while neither AreStatic nor AreNotStatic matched.

No snapshot changes: every member in every test architecture has a non-null IsStatic, and there is no fluent path to a stub member today, so the fix is not observable from a test.