### PR TITLE
Add NotBeNestedIn/AreNotNestedIn and Document the Unreachable ShouldRelateTo*That classes

### DIFF
--- a/ArchUnitNET/Fluent/Syntax/Elements/Members/FieldMembers/ShouldRelateToFieldMembersThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Members/FieldMembers/ShouldRelateToFieldMembersThat.cs
@@ -4,6 +4,9 @@ using static ArchUnitNET.Fluent.Syntax.ConjunctionFactory;
 
 namespace ArchUnitNET.Fluent.Syntax.Elements.Members.FieldMembers
 {
+    // No fluent method currently returns this class - it can't be reached, only constructed
+    // reflectively by a caller with a hand-built IArchRuleCreator. Kept for API symmetry with the
+    // other ShouldRelateTo*That classes rather than removed as a breaking change.
     public sealed class ShouldRelateToFieldMembersThat<TRuleTypeShouldConjunction, TRuleType>
         : AddFieldMemberPredicate<TRuleTypeShouldConjunction, TRuleType>
         where TRuleType : ICanBeAnalyzed

--- a/ArchUnitNET/Fluent/Syntax/Elements/Members/PropertyMembers/ShouldRelateToPropertyMembersThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Members/PropertyMembers/ShouldRelateToPropertyMembersThat.cs
@@ -4,6 +4,9 @@ using static ArchUnitNET.Fluent.Syntax.ConjunctionFactory;
 
 namespace ArchUnitNET.Fluent.Syntax.Elements.Members.PropertyMembers
 {
+    // No fluent method currently returns this class - it can't be reached, only constructed
+    // reflectively by a caller with a hand-built IArchRuleCreator. Kept for API symmetry with the
+    // other ShouldRelateTo*That classes rather than removed as a breaking change.
     public sealed class ShouldRelateToPropertyMembersThat<TNextElement, TRuleType>
         : AddPropertyMemberPredicate<TNextElement, TRuleType>
         where TRuleType : ICanBeAnalyzed

--- a/ArchUnitNET/Fluent/Syntax/Elements/Members/ShouldRelateToMembersThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Members/ShouldRelateToMembersThat.cs
@@ -6,6 +6,9 @@ using static ArchUnitNET.Fluent.Syntax.ConjunctionFactory;
 
 namespace ArchUnitNET.Fluent.Syntax.Elements.Members
 {
+    // No fluent method currently returns this class - it can't be reached, only constructed
+    // reflectively by a caller with a hand-built IArchRuleCreator. Kept for API symmetry with the
+    // other ShouldRelateTo*That classes rather than removed as a breaking change.
     public class ShouldRelateToMembersThat<TRuleTypeShouldConjunction, TRuleType>
         : AddMemberPredicate<TRuleTypeShouldConjunction, TRuleType, IMember>
         where TRuleType : ICanBeAnalyzed

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/AddTypeCondition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/AddTypeCondition.cs
@@ -82,6 +82,13 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         public TNextElement NotBeAssignableTo(IEnumerable<IType> types) => NotBeAssignableTo(new ObjectProvider<IType>(types));
         public TNextElement NotBeAssignableTo(IEnumerable<Type> types) => NotBeAssignableTo(new SystemTypeObjectProvider<IType>(types));
 
+        public TNextElement NotBeNestedIn() => NotBeNestedIn(new ObjectProvider<IType>());
+        public TNextElement NotBeNestedIn(params IType[] types) => NotBeNestedIn(new ObjectProvider<IType>(types));
+        public TNextElement NotBeNestedIn(params Type[] types) => NotBeNestedIn(new SystemTypeObjectProvider<IType>(types));
+        public TNextElement NotBeNestedIn(IObjectProvider<IType> types) => CreateNextElement(TypeConditionsDefinition<TRuleType>.NotBeNestedIn(types));
+        public TNextElement NotBeNestedIn(IEnumerable<IType> types) => NotBeNestedIn(new ObjectProvider<IType>(types));
+        public TNextElement NotBeNestedIn(IEnumerable<Type> types) => NotBeNestedIn(new SystemTypeObjectProvider<IType>(types));
+
         public TNextElement NotBeValueTypes() => CreateNextElement(TypeConditionsDefinition<TRuleType>.NotBeValueTypes());
         public TNextElement NotBeEnums() => CreateNextElement(TypeConditionsDefinition<TRuleType>.NotBeEnums());
         public TNextElement NotBeStructs() => CreateNextElement(TypeConditionsDefinition<TRuleType>.NotBeStructs());

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/AddTypePredicate.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/AddTypePredicate.cs
@@ -74,6 +74,13 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
         public TNextElement AreNotAssignableTo(IEnumerable<IType> types) => AreNotAssignableTo(new ObjectProvider<IType>(types));
         public TNextElement AreNotAssignableTo(IEnumerable<Type> types) => AreNotAssignableTo(new SystemTypeObjectProvider<IType>(types));
 
+        public TNextElement AreNotNestedIn() => AreNotNestedIn(new ObjectProvider<IType>());
+        public TNextElement AreNotNestedIn(params IType[] types) => AreNotNestedIn(new ObjectProvider<IType>(types));
+        public TNextElement AreNotNestedIn(params Type[] types) => AreNotNestedIn(new SystemTypeObjectProvider<IType>(types));
+        public TNextElement AreNotNestedIn(IObjectProvider<IType> types) => CreateNextElement(TypePredicatesDefinition<TRuleType>.AreNotNestedIn(types));
+        public TNextElement AreNotNestedIn(IEnumerable<IType> types) => AreNotNestedIn(new ObjectProvider<IType>(types));
+        public TNextElement AreNotNestedIn(IEnumerable<Type> types) => AreNotNestedIn(new SystemTypeObjectProvider<IType>(types));
+
         public TNextElement AreNotValueTypes() => CreateNextElement(TypePredicatesDefinition<TRuleType>.AreNotValueTypes());
         public TNextElement AreNotEnums() => CreateNextElement(TypePredicatesDefinition<TRuleType>.AreNotEnums());
         public TNextElement AreNotStructs() => CreateNextElement(TypePredicatesDefinition<TRuleType>.AreNotStructs());

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/ShouldRelateToClassesThat.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/Classes/ShouldRelateToClassesThat.cs
@@ -4,6 +4,9 @@ using static ArchUnitNET.Fluent.Syntax.ConjunctionFactory;
 
 namespace ArchUnitNET.Fluent.Syntax.Elements.Types.Classes
 {
+    // No fluent method currently returns this class - it can't be reached, only constructed
+    // reflectively by a caller with a hand-built IArchRuleCreator. Kept for API symmetry with the
+    // other ShouldRelateTo*That classes rather than removed as a breaking change.
     public sealed class ShouldRelateToClassesThat<TNextElement, TRuleType>
         : AddClassPredicate<TNextElement, TRuleType>
         where TRuleType : ICanBeAnalyzed

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/TypeConditionsDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/TypeConditionsDefinition.cs
@@ -133,6 +133,46 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             return new OrderedArchitectureCondition<TRuleType>(Condition, description);
         }
 
+        public static IOrderedCondition<TRuleType> NotBeNestedIn(
+            IObjectProvider<IType> objectProvider
+        )
+        {
+            var sizedObjectProvider = objectProvider as ISizedObjectProvider<IType>;
+            IEnumerable<ConditionResult> Condition(
+                IEnumerable<TRuleType> ruleTypes,
+                Architecture architecture
+            )
+            {
+                var typeList = objectProvider.GetObjects(architecture).ToList();
+                var failDescription =
+                    sizedObjectProvider != null && sizedObjectProvider.Count == 0
+                        ? "is nested in no types (always true)"
+                        : "is nested in " + objectProvider.Description;
+                foreach (var ruleType in ruleTypes)
+                {
+                    if (
+                        typeList.Any(outerType =>
+                            ruleType.FullName.StartsWith(outerType.FullName + "+")
+                        )
+                    )
+                    {
+                        yield return new ConditionResult(ruleType, false, failDescription);
+                    }
+                    else
+                    {
+                        yield return new ConditionResult(ruleType, true);
+                    }
+                }
+            }
+
+            var description = objectProvider.FormatDescription(
+                "not be nested in no types (always true)",
+                "not be nested in",
+                "not be nested in"
+            );
+            return new OrderedArchitectureCondition<TRuleType>(Condition, description);
+        }
+
         public static IOrderedCondition<TRuleType> BeValueTypes()
         {
             return new SimpleCondition<TRuleType>(

--- a/ArchUnitNET/Fluent/Syntax/Elements/Types/TypePredicatesDefinition.cs
+++ b/ArchUnitNET/Fluent/Syntax/Elements/Types/TypePredicatesDefinition.cs
@@ -59,6 +59,24 @@ namespace ArchUnitNET.Fluent.Syntax.Elements.Types
             return new ArchitecturePredicate<T>(Condition, description);
         }
 
+        public static IPredicate<T> AreNotNestedIn(IObjectProvider<IType> objectProvider)
+        {
+            IEnumerable<T> Condition(IEnumerable<T> ruleTypes, Architecture architecture)
+            {
+                var types = objectProvider.GetObjects(architecture);
+                return ruleTypes.Where(type =>
+                    !types.Any(outerType => type.FullName.StartsWith(outerType.FullName + "+"))
+                );
+            }
+
+            var description = objectProvider.FormatDescription(
+                "are not nested in no types (always true)",
+                "are not nested in",
+                "are not nested in"
+            );
+            return new ArchitecturePredicate<T>(Condition, description);
+        }
+
         public static IPredicate<T> AreValueTypes()
         {
             return new SimplePredicate<T>(

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/TypeSyntaxElementsTests.NotBeNestedInTest.verified.txt
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/Snapshots/TypeSyntaxElementsTests.NotBeNestedInTest.verified.txt
@@ -1,0 +1,279 @@
+﻿===== No Violations =====
+
+----- Conditions -----
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in Types that are "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+----- Predicates -----
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in Types that are "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+===== Violations =====
+
+----- Conditions -----
+
+Query: Types that are "TypeNamespace.OuterClassA+InnerClassA" should not be nested in "TypeNamespace.OuterClassA"
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is nested in "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.OuterClassA+InnerClassA" should not be nested in "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is nested in "TypeNamespace.OuterClassA"
+
+
+
+Query: Types that are "TypeNamespace.OuterClassA+InnerClassA" should not be nested in "TypeNamespace.OuterClassA"
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is nested in "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.OuterClassA+InnerClassA" should not be nested in "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is nested in "TypeNamespace.OuterClassA"
+
+
+
+Query: Types that are "TypeNamespace.OuterClassA+InnerClassA" should not be nested in Types that are "TypeNamespace.OuterClassA"
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is nested in Types that are "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.OuterClassA+InnerClassA" should not be nested in Types that are "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is nested in Types that are "TypeNamespace.OuterClassA"
+
+
+
+Query: Types that are "TypeNamespace.OuterClassA+InnerClassA" should not be nested in "TypeNamespace.OuterClassA"
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is nested in "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.OuterClassA+InnerClassA" should not be nested in "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is nested in "TypeNamespace.OuterClassA"
+
+
+
+Query: Types that are "TypeNamespace.OuterClassA+InnerClassA" should not be nested in "TypeNamespace.OuterClassA"
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is nested in "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.OuterClassA+InnerClassA" should not be nested in "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is nested in "TypeNamespace.OuterClassA"
+
+
+
+----- Predicates -----
+
+Query: Types that are "TypeNamespace.OuterClassA+InnerClassA" should be Types that are not nested in "TypeNamespace.OuterClassA"
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is not Types that are not nested in "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.OuterClassA+InnerClassA" should be Types that are not nested in "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is not Types that are not nested in "TypeNamespace.OuterClassA"
+
+
+
+Query: Types that are "TypeNamespace.OuterClassA+InnerClassA" should be Types that are not nested in "TypeNamespace.OuterClassA"
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is not Types that are not nested in "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.OuterClassA+InnerClassA" should be Types that are not nested in "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is not Types that are not nested in "TypeNamespace.OuterClassA"
+
+
+
+Query: Types that are "TypeNamespace.OuterClassA+InnerClassA" should be Types that are not nested in Types that are "TypeNamespace.OuterClassA"
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is not Types that are not nested in Types that are "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.OuterClassA+InnerClassA" should be Types that are not nested in Types that are "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is not Types that are not nested in Types that are "TypeNamespace.OuterClassA"
+
+
+
+Query: Types that are "TypeNamespace.OuterClassA+InnerClassA" should be Types that are not nested in "TypeNamespace.OuterClassA"
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is not Types that are not nested in "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.OuterClassA+InnerClassA" should be Types that are not nested in "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is not Types that are not nested in "TypeNamespace.OuterClassA"
+
+
+
+Query: Types that are "TypeNamespace.OuterClassA+InnerClassA" should be Types that are not nested in "TypeNamespace.OuterClassA"
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is not Types that are not nested in "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.OuterClassA+InnerClassA" should be Types that are not nested in "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is not Types that are not nested in "TypeNamespace.OuterClassA"
+
+
+
+===== Multiple inputs =====
+
+Query: Types that are "TypeNamespace.NonNestedClass" or "TypeNamespace.OuterClassB+InnerClassB" should not be nested in "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Result: True
+Description: TypeNamespace.OuterClassB+InnerClassB passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" or "TypeNamespace.OuterClassA+InnerClassA" should not be nested in "TypeNamespace.OuterClassA"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Result: False
+Description: TypeNamespace.OuterClassA+InnerClassA is nested in "TypeNamespace.OuterClassA"
+Message: 
+"Types that are "TypeNamespace.NonNestedClass" or "TypeNamespace.OuterClassA+InnerClassA" should not be nested in "TypeNamespace.OuterClassA"" failed:
+	TypeNamespace.OuterClassA+InnerClassA is nested in "TypeNamespace.OuterClassA"
+
+
+
+===== Multiple arguments =====
+
+----- Conditions -----
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in "TypeNamespace.OuterClassA" or "TypeNamespace.OuterClassB"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in "TypeNamespace.OuterClassA" or "TypeNamespace.OuterClassB"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in "TypeNamespace.OuterClassA" or "TypeNamespace.OuterClassB"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in "TypeNamespace.OuterClassA" or "TypeNamespace.OuterClassB"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+----- Predicates -----
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in "TypeNamespace.OuterClassA" or "TypeNamespace.OuterClassB"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in "TypeNamespace.OuterClassA" or "TypeNamespace.OuterClassB"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in "TypeNamespace.OuterClassA" or "TypeNamespace.OuterClassB"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in "TypeNamespace.OuterClassA" or "TypeNamespace.OuterClassB"
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+===== Empty Arguments =====
+
+----- Conditions -----
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in no types (always true)
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in no types (always true)
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should not be nested in no types (always true)
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+----- Predicates -----
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in no types (always true)
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in no types (always true)
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+
+Query: Types that are "TypeNamespace.NonNestedClass" should be Types that are not nested in no types (always true)
+Result: True
+Description: TypeNamespace.NonNestedClass passed
+Message: 
+All Evaluations passed
+

--- a/ArchUnitNETTests/Fluent/Syntax/Elements/TypeSyntaxElementsTests.cs
+++ b/ArchUnitNETTests/Fluent/Syntax/Elements/TypeSyntaxElementsTests.cs
@@ -411,6 +411,80 @@ namespace ArchUnitNETTests.Fluent.Syntax.Elements
         }
 
         [Fact]
+        public async Task NotBeNestedInTest()
+        {
+            var helper = new TypeAssemblyTestHelper();
+
+            helper.AddSnapshotHeader("No Violations");
+            var should = Types().That().Are(helper.NonNestedClass).Should();
+
+            helper.AddSnapshotSubHeader("Conditions");
+            should.NotBeNestedIn(helper.OuterClassA).AssertNoViolations(helper);
+            should.NotBeNestedIn(helper.OuterClassASystemType).AssertNoViolations(helper);
+            should.NotBeNestedIn(Types().That().Are(helper.OuterClassA)).AssertNoViolations(helper);
+            should.NotBeNestedIn(new List<IType> { helper.OuterClassA }).AssertNoViolations(helper);
+            should.NotBeNestedIn(new List<System.Type> { helper.OuterClassASystemType }).AssertNoViolations(helper);
+
+            helper.AddSnapshotSubHeader("Predicates");
+            should.Be(Types().That().AreNotNestedIn(helper.OuterClassA)).AssertNoViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(helper.OuterClassASystemType)).AssertNoViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(Types().That().Are(helper.OuterClassA))).AssertNoViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(new List<IType> { helper.OuterClassA })).AssertNoViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(new List<System.Type> { helper.OuterClassASystemType })).AssertNoViolations(helper);
+
+            helper.AddSnapshotHeader("Violations");
+            should = Types().That().Are(helper.InnerClassA).Should();
+
+            helper.AddSnapshotSubHeader("Conditions");
+            should.NotBeNestedIn(helper.OuterClassA).AssertOnlyViolations(helper);
+            should.NotBeNestedIn(helper.OuterClassASystemType).AssertOnlyViolations(helper);
+            should.NotBeNestedIn(Types().That().Are(helper.OuterClassA)).AssertOnlyViolations(helper);
+            should.NotBeNestedIn(new List<IType> { helper.OuterClassA }).AssertOnlyViolations(helper);
+            should.NotBeNestedIn(new List<System.Type> { helper.OuterClassASystemType }).AssertOnlyViolations(helper);
+
+            helper.AddSnapshotSubHeader("Predicates");
+            should.Be(Types().That().AreNotNestedIn(helper.OuterClassA)).AssertOnlyViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(helper.OuterClassASystemType)).AssertOnlyViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(Types().That().Are(helper.OuterClassA))).AssertOnlyViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(new List<IType> { helper.OuterClassA })).AssertOnlyViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(new List<System.Type> { helper.OuterClassASystemType })).AssertOnlyViolations(helper);
+
+            helper.AddSnapshotHeader("Multiple inputs");
+            Types().That().Are(helper.NonNestedClass, helper.InnerClassB).Should().NotBeNestedIn(helper.OuterClassA).AssertNoViolations(helper);
+            Types().That().Are(helper.NonNestedClass, helper.InnerClassA).Should().NotBeNestedIn(helper.OuterClassA).AssertAnyViolations(helper);
+
+            helper.AddSnapshotHeader("Multiple arguments");
+            should = Types().That().Are(helper.NonNestedClass).Should();
+
+            helper.AddSnapshotSubHeader("Conditions");
+            should.NotBeNestedIn(helper.OuterClassA, helper.OuterClassB).AssertNoViolations(helper);
+            should.NotBeNestedIn(new List<IType> { helper.OuterClassA, helper.OuterClassB }).AssertNoViolations(helper);
+            should.NotBeNestedIn(helper.OuterClassASystemType, helper.OuterClassBSystemType).AssertNoViolations(helper);
+            should.NotBeNestedIn(new List<System.Type> { helper.OuterClassASystemType, helper.OuterClassBSystemType }).AssertNoViolations(helper);
+
+            helper.AddSnapshotSubHeader("Predicates");
+            should.Be(Types().That().AreNotNestedIn(helper.OuterClassA, helper.OuterClassB)).AssertNoViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(new List<IType> { helper.OuterClassA, helper.OuterClassB })).AssertNoViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(helper.OuterClassASystemType, helper.OuterClassBSystemType)).AssertNoViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(new List<System.Type> { helper.OuterClassASystemType, helper.OuterClassBSystemType })).AssertNoViolations(helper);
+
+            helper.AddSnapshotHeader("Empty Arguments");
+            should = Types().That().Are(helper.NonNestedClass).Should();
+
+            helper.AddSnapshotSubHeader("Conditions");
+            should.NotBeNestedIn().AssertNoViolations(helper);
+            should.NotBeNestedIn(new List<IType>()).AssertNoViolations(helper);
+            should.NotBeNestedIn(new List<System.Type>()).AssertNoViolations(helper);
+
+            helper.AddSnapshotSubHeader("Predicates");
+            should.Be(Types().That().AreNotNestedIn()).AssertNoViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(new List<IType>())).AssertNoViolations(helper);
+            should.Be(Types().That().AreNotNestedIn(new List<System.Type>())).AssertNoViolations(helper);
+
+            await helper.AssertSnapshotMatches();
+        }
+
+        [Fact]
         public async Task BeValueTypesTest()
         {
             var helper = new TypeAssemblyTestHelper();


### PR DESCRIPTION
BeNestedIn/AreNestedIn had no negated sibling, unlike every other type condition/predicate pair, so BeNestedInTest had no NotBeNestedInTest counterpart. Add TypeConditionsDefinition.NotBeNestedIn, TypePredicatesDefinition.AreNotNestedIn, and the six overloads each in AddTypeCondition/AddTypePredicate, mirroring NotBeAssignableTo/AreNotAssignableTo.

ShouldRelateToMembersThat, ShouldRelateToPropertyMembersThat, ShouldRelateToFieldMembersThat, and ShouldRelateToClassesThat are public but unreachable - no fluent method returns them, unlike their siblings for Types/Interfaces/Attributes/MethodMembers. Leave them in place (removing a public type is a breaking change) but note why they are unreachable so the 0% coverage doesn't read as an oversight.