### PR TITLE
Update TUnit package to version 0.90.45 for TUnitTests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,9 @@ jobs:
         with:
           cache: false
       - name: Run tests
+        run: dotnet test -c Debug ArchUnit.TestsWithoutTUnit.slnf
+      - name: Run TUnit tests
+        working-directory: ./ArchUnitNET.TUnitTests
         run: dotnet test -c Debug
   publish-docs:
     name: Publish documentation

--- a/ArchUnit.TestsWithoutTUnit.slnf
+++ b/ArchUnit.TestsWithoutTUnit.slnf
@@ -1,0 +1,15 @@
+{
+  "solution": {
+		"path": "ArchUnit.sln",
+		"projects": [
+		  "ArchUnitNET.NUnitTests\\ArchUnitNET.NUnitTests.csproj",
+		  "ArchUnitNETTests\\ArchUnitNETTests.csproj",
+		  "ArchUnitNET.MSTestV3Tests\\ArchUnitNET.MSTestV3Tests.csproj",
+		  "ArchUnitNET.xUnitV3Tests\\ArchUnitNET.xUnitV3Tests.csproj",
+		  "ArchUnitNET.MSTestV4Tests\\ArchUnitNET.MSTestV4Tests.csproj",
+		  "ExampleTest\\ExampleTest.csproj",
+		  "ArchUnitNET.MSTestV2Tests\\ArchUnitNET.MSTestV2Tests.csproj",
+		  "ArchUnitNET.xUnitTests\\ArchUnitNET.xUnitTests.csproj"
+		]
+  }
+}

--- a/ArchUnit.sln
+++ b/ArchUnit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.7.11925.98 stable
+VisualStudioVersion = 18.7.11925.98
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestAssembly", "TestAssembly\TestAssembly.csproj", "{7DEF5F34-AB86-457B-819D-5E7387B3FF87}"
 EndProject
@@ -65,8 +65,25 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassAssembly", "TestAssemb
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A780B3D6-C525-4270-ABF1-63BA65EA1593}"
 	ProjectSection(SolutionItems) = preProject
+		ArchUnit.TestsWithoutTUnit.slnf = ArchUnit.TestsWithoutTUnit.slnf
 		README.md = README.md
 		renovate.json = renovate.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{38699834-8620-4254-AB98-C19586AD3952}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{5B3E7A23-F91B-4506-9879-B8CAD13F4AE0}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yaml = .github\workflows\build.yaml
+		.github\workflows\codeql.yml = .github\workflows\codeql.yml
+		.github\workflows\label-issues.yaml = .github\workflows\label-issues.yaml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEMPLATE", "{84BF2DBC-C8FA-46CE-9419-1CE4E3C4D175}"
+	ProjectSection(SolutionItems) = preProject
+		.github\ISSUE_TEMPLATE\bug_report.yml = .github\ISSUE_TEMPLATE\bug_report.yml
+		.github\ISSUE_TEMPLATE\config.yml = .github\ISSUE_TEMPLATE\config.yml
+		.github\ISSUE_TEMPLATE\feature_request.yml = .github\ISSUE_TEMPLATE\feature_request.yml
 	EndProjectSection
 EndProject
 Global
@@ -444,6 +461,8 @@ Global
 		{05F40E4D-94EC-4DF7-B0FA-1BCBFDF56088} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 		{1D0187EB-9D04-4CF3-AE63-0C0E97FCB49C} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
 		{2C04EB93-5AE0-474C-B328-145A734A5E2B} = {B1191F18-91CB-4387-B775-A5EB64D3AC30}
+		{5B3E7A23-F91B-4506-9879-B8CAD13F4AE0} = {38699834-8620-4254-AB98-C19586AD3952}
+		{84BF2DBC-C8FA-46CE-9419-1CE4E3C4D175} = {38699834-8620-4254-AB98-C19586AD3952}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D1A8274D-32D6-44DB-9BB3-1A5B273709AF}

--- a/ArchUnitNET.TUnitTests/ArchUnitNET.TUnitTests.csproj
+++ b/ArchUnitNET.TUnitTests/ArchUnitNET.TUnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="TUnit" Version="0.61.39" />
+    <PackageReference Include="TUnit" Version="0.90.45" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ArchUnitNET.TUnit\ArchUnitNET.TUnit.csproj" />

--- a/ArchUnitNET.TUnitTests/global.json
+++ b/ArchUnitNET.TUnitTests/global.json
@@ -1,0 +1,10 @@
+{
+  "sdk": {
+    "version": "10.0.400",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
With this PR we aim to update the TUnit package for the TUnitTests to version 0.90.45.  For newer TUnit versions on .NET 10 the legacy VSTest bridge is no longer supported. Instead TUnit natively supports running as a stanadalone executable via Microsoft.Testing.Platform (MTP). But since some of older test projects don't support MTP we needed to split the "Run tests" step in our build pipeline. Therefore, we now run TUnitTests explicitly via MTP (configured via local `global.json` file) and all other test projects (specified via solution filter file `ArchUnit.TestsWithoutTUnit.slnf`) as before via VSTest.

Independently, we updated the solution file to contain the new solution filter, as well as workflow and issue template files to improve the project structure and make it easier to edit those files via Visual Studio.